### PR TITLE
feat:add global request and response middleware

### DIFF
--- a/src/Http/Middleware/RequestMiddleware.php
+++ b/src/Http/Middleware/RequestMiddleware.php
@@ -1,0 +1,40 @@
+<?php
+namespace Iquesters\Foundation\Http\Middleware;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequestMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Starting with ######
+        // This should always be the first middleware
+        Log::debug("##################################################");
+        Log::debug("Start of RequestMiddleware...");
+        Log::debug("--------------------------------------------------");
+        Log::debug("Request full URL = " . $request->fullUrl());
+        Log::debug("--------------------------------------------------");
+        // Log::debug("Request from client");
+        // Log::debug("--------------------------------------------------");
+        // Log::debug($request);
+        // Log::debug("--------------------------------------------------");
+
+        Log::debug("Processing request...");
+
+        // do your request processing here
+
+        Log::debug("Processing request done.");
+        Log::debug("--------------------------------------------------");
+        Log::debug("Forwarding to next...");
+        Log::debug("End of RequestMiddleware.");
+        Log::debug("==================================================");
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/ResponseMiddleware.php
+++ b/src/Http/Middleware/ResponseMiddleware.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Iquesters\Foundation\Http\Middleware;
+
+// use App\Models\User;
+// use App\Models\UserMetas;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResponseMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+        Log::debug("==================================================");
+        Log::debug("Start of ResponseMiddleware...");
+        Log::debug("--------------------------------------------------");
+        Log::debug("No processing on response needed.");
+        Log::debug("--------------------------------------------------");
+        // Log::debug("Response from controller");
+        // Log::debug("--------------------------------------------------");
+        // // Log::debug($response);
+        // Log::debug("--------------------------------------------------");
+        Log::debug("Processing response...");
+
+        // do your response processing here
+
+        // force redirection of user data
+        // if (Auth::check()) {
+        //     $user = User::find(Auth::user()->id);
+
+        //     $redirect_url = $user->meta()?->redirect_url ?? null;
+
+        //     if (isset($redirect_url)) {
+        //         UserMetas::where([
+        //             'ref_user' => Auth::user()->id,
+        //             'key' => 'redirect_url',
+        //         ])->delete();
+        //         return redirect($redirect_url);
+        //     }
+        // }
+
+        Log::debug("Processing response done.");
+        Log::debug("--------------------------------------------------");
+
+        Log::debug("End of ResponseMiddleware.");
+        // Ending with ######
+        // This should always be the last middleware
+        Log::debug("##################################################");
+
+        return $response;
+    }
+}


### PR DESCRIPTION
## 📝 Description
This feature introduces two distinct **HTTP middleware classes** to the `iquesters/foundation` package to handle cross-cutting concerns separately — one for **Request** processing and one for **Response** processing.  

- **RequestMiddleware**  
  Executes *before* the request reaches the controller.  


- **ResponseMiddleware**  
  Executes *after* the controller has processed the request and returned a response.  

## ✅ Tasks

- [x] **Create RequestMiddleware:**  
  Develop the middleware class focused on processing incoming `$request` data (e.g., logging, standardization).

- [x] **Create ResponseMiddleware:**  
  Develop the middleware class focused on processing outgoing `$response` data (e.g., logging, headers, execution time).

- [x] **Implement Request Logic:**  
  Add all required request-side processing functionality.

- [x] **Implement Response Logic:**  
  Add all required response-side processing functionality.
