### PR TITLE
Add page-title, meta-description and tabs to entity and master data pages

### DIFF
--- a/resources/views/entity/index.blade.php
+++ b/resources/views/entity/index.blade.php
@@ -1,5 +1,19 @@
 @extends('userinterface::layouts.app')
 
+@section('page-title', \Iquesters\Foundation\Helpers\MetaHelper::make(['Entity']))
+@section('meta-description', \Iquesters\Foundation\Helpers\MetaHelper::description('List of Entities'))
+
+@php
+    $tabs = [
+        [
+            'route' => 'entities.index',
+            'params' => [],
+            'icon' => 'fas fa-fw fa-cube',
+            'label' => 'Entity',
+        ],
+    ];
+@endphp
+
 @section('content')
 <div>
     {{-- <h5 class="mb-2 fs-6 text-muted">Entities</h5> --}}

--- a/resources/views/master_data/index.blade.php
+++ b/resources/views/master_data/index.blade.php
@@ -1,5 +1,19 @@
 @extends('userinterface::layouts.app')
 
+@section('page-title', \Iquesters\Foundation\Helpers\MetaHelper::make(['Master Data']))
+@section('meta-description', \Iquesters\Foundation\Helpers\MetaHelper::description('List of Master Data'))
+
+@php
+    $tabs = [
+        [
+            'route' => 'master-data.index',
+            'params' => [],
+            'icon' => 'fas fa-fw fa-database',
+            'label' => 'Master Data',
+        ],
+    ];
+@endphp
+
 @section('content')
 <div class="d-flex justify-content-between align-items-center mb-2">
     <h5 class="fs-6 text-muted">Total {{ $masterData->count() }} Master Data(s)</h5>


### PR DESCRIPTION
## Summary
Updated entity and master data views to align with the standard structure followed across other packages.

## Problem
The entity and master data pages were missing page-title, meta-description and tab navigation, making them inconsistent with other packages.

## Changes
- Added page-title and meta-description to entity index page
- Added tab navigation to entity index page
- Added page-title and meta-description to master data index page
- Added tab navigation to master data index page

## Testing
- Verified page title appears correctly in browser tab
- Verified tab navigation and history icon appear on both pages

Closes #22 