### PR TITLE
Fix: Resolve seeding error in PackageInfo and BaseServiceProvider

### DIFF
--- a/src/System/Package/PackageInfo.php
+++ b/src/System/Package/PackageInfo.php
@@ -207,6 +207,7 @@ abstract class PackageInfo
         
         if (class_exists($seederCommandClass)) {
             $bindings[] = [
+                'binding_name' => 'command.' . $this->module_name . '.seed',
                 'command_class' => $seederCommandClass,
                 'seeder_class' => $seederClass
             ];

--- a/src/System/Providers/BaseServiceProvider.php
+++ b/src/System/Providers/BaseServiceProvider.php
@@ -98,11 +98,12 @@ abstract class BaseServiceProvider extends ServiceProvider
 
         if ($bindings) {
             foreach ($bindings as $binding) {
+                $bindingName = $binding['binding_name'] ?? $binding['command_class'];
                 $commandClass = $binding['command_class'];
                 $seederClass = $binding['seeder_class'];
                 
                 // Bind the SeederCommand with its required constructor parameter
-                $this->app->bind($commandClass, function ($app) use ($commandClass, $seederClass) {
+                $this->app->bind($bindingName, function ($app) use ($commandClass, $seederClass) {
                     return new $commandClass($seederClass);
                 });
 
@@ -152,7 +153,7 @@ abstract class BaseServiceProvider extends ServiceProvider
         $allCommands = $commands ?? [];
         if ($bindings) {
             foreach ($bindings as $binding) {
-                $allCommands[] = $binding['command_class'];
+                $allCommands[] = $binding['binding_name'] ?? $binding['command_class'];
             }
         }
 


### PR DESCRIPTION
## Summary
This PR fixes a seeding error caused due to incorrect or inconsistent handling in:
- PackageInfo.php
- BaseServiceProvider.php

## Problem
Database seeding was failing due to improper configuration/logic in the package initialization.

## Solution
- Updated PackageInfo.php to ensure correct package metadata handling
- Fixed BaseServiceProvider to properly register and boot services required for seeding

The seed command did not fail because of `BaseSeeder` or `FoundationSeeder`.
It failed because auto-discovered seeder commands shared the same container binding:

```text
Iquesters\Foundation\Console\SeederCommand
```

The fix was to give each module seed command its own binding:

```text
command.foundation.seed
command.organisation.seed
```

This lets multiple packages reuse the same `SeederCommand` class without overwriting each other.

## Related Issue
Closes #25