### PR TITLE
enhancement: add Business Entity Builder with Modal-Based Entity Selection and Relationship, Association Configuration

### DIFF
--- a/database/migrations/2025_10_10_000009_create_business_entities_table.php
+++ b/database/migrations/2025_10_10_000009_create_business_entities_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('business_entities', function (Blueprint $table) {
+            $table->id();
+            $table->ulid('uid')->unique();
+            $table->unsignedBigInteger('ref_module')->nullable();
+            $table->string('business_entity_name');
+            $table->string('slug')->nullable();
+            $table->string('desc')->nullable();
+            $table->longText('field_mapping')->nullable();
+            $table->string('status')->default('unknown');
+            $table->unsignedBigInteger('created_by')->default(0);
+            $table->unsignedBigInteger('updated_by')->default(0);
+            $table->timestamps();
+
+            $table->foreign('ref_module')
+                ->references('id')
+                ->on('modules')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+        });
+
+        Schema::create('business_entity_metas', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('ref_parent')->nullable();
+            $table->string('meta_key');
+            $table->longText('meta_value')->nullable();
+            $table->string('status')->default('unknown');
+            $table->unsignedBigInteger('created_by')->default(0);
+            $table->unsignedBigInteger('updated_by')->default(0);
+            $table->timestamps();
+
+            $table->foreign('ref_parent')
+                ->references('id')
+                ->on('business_entities')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('business_entity_metas');
+        Schema::dropIfExists('business_entities');
+    }
+};

--- a/database/seeders/FoundationSeeder.php
+++ b/database/seeders/FoundationSeeder.php
@@ -63,6 +63,11 @@ class FoundationSeeder extends BaseSeeder
                 // ]
             ],
             [
+                "icon" => "fas fa-diagram-project",
+                "label" => "Business Entities",
+                "route" => "business-entities.index",
+            ],
+            [
                 "icon" => "fas fa-layer-group",
                 "label" => "Queue OLD",
                 "route" => "smart-messenger.queue-management",

--- a/resources/views/business_entity/create-edit.blade.php
+++ b/resources/views/business_entity/create-edit.blade.php
@@ -1,424 +1,503 @@
 @extends('userinterface::layouts.app')
 
 @section('content')
-@php
-    $isCreating = $isCreating ?? true;
+    @php
+        $isCreating = $isCreating ?? true;
 
-    $entityOptions = $entities->map(function ($entity) {
-        $fields = is_string($entity->fields)
-            ? json_decode($entity->fields, true)
-            : ($entity->fields ?? []);
+        $entityOptions = $entities
+            ->map(function ($entity) {
+                $fields = is_string($entity->fields) ? json_decode($entity->fields, true) : $entity->fields ?? [];
 
-        $metaFields = is_string($entity->meta_fields)
-            ? json_decode($entity->meta_fields, true)
-            : ($entity->meta_fields ?? []);
+                $metaFields = is_string($entity->meta_fields)
+                    ? json_decode($entity->meta_fields, true)
+                    : $entity->meta_fields ?? [];
 
-        return [
-            'uid' => $entity->uid,
-            'entity_name' => $entity->entity_name,
-            'slug' => $entity->slug,
-            'fields' => array_values($fields ?: []),
-            'meta_fields' => array_values($metaFields ?: []),
-        ];
-    })->values();
+                $isPivot = collect($entity->metas ?? [])->contains(function ($meta) {
+                    return $meta->meta_key === 'is_pivot' && strtolower((string) $meta->meta_value) === 'true';
+                });
 
-    $fieldMapping = $businessEntity?->field_mapping ?? [];
-    if (is_string($fieldMapping)) {
-        $fieldMapping = json_decode($fieldMapping, true) ?: [];
-    }
-@endphp
+                return [
+                    'uid' => $entity->uid,
+                    'entity_name' => $entity->entity_name,
+                    'slug' => $entity->slug,
+                    'fields' => array_values($fields ?: []),
+                    'meta_fields' => array_values($metaFields ?: []),
+                    'is_pivot' => $isPivot,
+                ];
+            })
+            ->values();
 
-<form id="businessEntityForm" method="POST" action="{{ $isCreating ? route('business-entities.store') : route('business-entities.update', $businessEntity->uid) }}">
-    @csrf
-    @if(!$isCreating)
-        @method('PUT')
-    @endif
+        $fieldMapping = $businessEntity?->field_mapping ?? [];
+        if (is_string($fieldMapping)) {
+            $fieldMapping = json_decode($fieldMapping, true) ?: [];
+        }
+    @endphp
 
-    <input type="hidden" id="field_mapping" name="field_mapping" value="{{ old('field_mapping') }}">
+    <form id="businessEntityForm" method="POST"
+        action="{{ $isCreating ? route('business-entities.store') : route('business-entities.update', $businessEntity->uid) }}">
+        @csrf
+        @if (!$isCreating)
+            @method('PUT')
+        @endif
 
-    <div class="mb-3">
+        <input type="hidden" id="field_mapping" name="field_mapping" value="{{ old('field_mapping') }}">
+
+        <div class="mb-3">
             <div class="sticky-top business-entity-sticky-top bg-body pb-2">
-            <div class="mb-3">
-                <h5 class="mb-1 fs-6">
-                    {{ $isCreating ? 'Create New Business Entity' : 'Edit Business Entity' }}
-                </h5>
-                <p class="mb-0 text-muted">
-                    UID will be auto-generated
-                </p>
-            </div>
-
-            <div class="mb-3">
-                <div class="row px-2">
-                    <div class="col-md-4">
-                        <label for="business_entity_name" class="form-label">
-                            Business Entity Name <span class="text-danger">*</span>
-                        </label>
-                        <input type="text"
-                            class="form-control @error('business_entity_name') is-invalid @enderror"
-                            id="business_entity_name"
-                            name="business_entity_name"
-                            value="{{ old('business_entity_name', $businessEntity->business_entity_name ?? '') }}"
-                            required>
-                        @error('business_entity_name')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
-
-                    <div class="col-md-4">
-                        <label for="ref_module" class="form-label">
-                            Module <span class="text-danger">*</span>
-                            <small>If no module is available, please create one.</small>
-                        </label>
-
-                        <select
-                            class="form-select @error('ref_module') is-invalid @enderror"
-                            id="ref_module"
-                            name="ref_module"
-                            required>
-                            <option value="">- Select Module -</option>
-
-                            @foreach($modules as $module)
-                                <option value="{{ $module->id }}"
-                                    {{ old('ref_module', $businessEntity->ref_module ?? null) == $module->id ? 'selected' : '' }}>
-                                    {{ ucfirst(str_replace('-', ' ', $module->name)) }}
-                                </option>
-                            @endforeach
-                        </select>
-                        @error('ref_module')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
-
-                    <div class="col-md-4">
-                        <label for="desc" class="form-label">Description</label>
-                        <textarea class="form-control @error('desc') is-invalid @enderror"
-                            id="desc"
-                            name="desc"
-                            rows="3">{{ old('desc', $businessEntity->desc ?? '') }}</textarea>
-                        @error('desc')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
+                <div class="mb-3">
+                    <h5 class="mb-1 fs-6">
+                        {{ $isCreating ? 'Create New Business Entity' : 'Edit Business Entity' }}
+                    </h5>
+                    <p class="mb-0 text-muted">
+                        UID will be auto-generated
+                    </p>
                 </div>
-            </div>
 
-            <div class="alert alert-info mb-2">
-                Select entities, choose primary and meta fields, then save. Only selected fields are stored in <code>field_mapping</code>.
-            </div>
-        </div>
-
-        <div class="accordion" id="businessEntityAccordion">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="selectedEntitiesHeader">
-                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#selectedEntities">
-                        Selected Entities / Tables
-                    </button>
-                </h2>
-                <div id="selectedEntities" class="accordion-collapse collapse show" data-bs-parent="#businessEntityAccordion">
-                    <div class="accordion-body">
-                        <div class="mb-3">
-                            <button type="button" id="primaryAddBusinessEntityItem" class="btn btn-sm btn-outline-primary add-business-entity-item">
-                                <i class="fa-regular fa-fw fa-plus"></i>
-                                <span class="ms-1">Add Entity</span>
-                            </button>
+                <div class="mb-3">
+                    <div class="row px-2">
+                        <div class="col-md-4">
+                            <label for="business_entity_name" class="form-label">
+                                Business Entity Name <span class="text-danger">*</span>
+                            </label>
+                            <input type="text" class="form-control @error('business_entity_name') is-invalid @enderror"
+                                id="business_entity_name" name="business_entity_name"
+                                value="{{ old('business_entity_name', $businessEntity->business_entity_name ?? '') }}"
+                                required>
+                            @error('business_entity_name')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
                         </div>
 
-                        <div id="selectedEntityPanels"></div>
+                        <div class="col-md-4">
+                            <label for="ref_module" class="form-label">
+                                Module <span class="text-danger">*</span>
+                                <small>If no module is available, please create one.</small>
+                            </label>
+
+                            <select class="form-select @error('ref_module') is-invalid @enderror" id="ref_module"
+                                name="ref_module" required>
+                                <option value="">- Select Module -</option>
+
+                                @foreach ($modules as $module)
+                                    <option value="{{ $module->id }}"
+                                        {{ old('ref_module', $businessEntity->ref_module ?? null) == $module->id ? 'selected' : '' }}>
+                                        {{ ucfirst(str_replace('-', ' ', $module->name)) }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            @error('ref_module')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <div class="col-md-4">
+                            <label for="desc" class="form-label">Description</label>
+                            <textarea class="form-control @error('desc') is-invalid @enderror" id="desc" name="desc" rows="3">{{ old('desc', $businessEntity->desc ?? '') }}</textarea>
+                            @error('desc')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                    </div>
+                </div>
+
+                <div class="alert alert-info mb-2">
+                    Select entities, choose primary and meta fields, then save. Only selected fields are stored in
+                    <code>field_mapping</code>.
+                </div>
+            </div>
+
+            <div class="accordion" id="businessEntityAccordion">
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="selectedEntitiesHeader">
+                        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#selectedEntities">
+                            Selected Entities / Tables
+                        </button>
+                    </h2>
+                    <div id="selectedEntities" class="accordion-collapse collapse show"
+                        data-bs-parent="#businessEntityAccordion">
+                        <div class="accordion-body">
+                            <div class="mb-3 d-flex justify-content-between align-items-center">
+                                <button type="button" id="primaryAddBusinessEntityItem"
+                                    class="btn btn-sm btn-outline-primary add-business-entity-item">
+                                    <i class="fa-regular fa-fw fa-plus"></i>
+                                    <span class="ms-1">Add Entity</span>
+                                </button>
+
+                                <button type="button" id="primaryAddAssociationItem"
+                                    class="btn btn-sm btn-outline-secondary add-association-item">
+                                    <i class="fa-solid fa-fw fa-link"></i>
+                                    <span class="ms-1">Add Association</span>
+                                </button>
+                            </div>
+
+                            <div id="selectedEntityPanels"></div>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <div class="d-flex align-items-center justify-content-end mb-3 gap-2">
-        <a href="{{ route('business-entities.index') }}" class="btn btn-sm btn-outline-dark">Cancel</a>
-        <button type="submit" class="btn btn-sm btn-outline-primary">
-            {{ $isCreating ? 'Create' : 'Update' }}
-        </button>
-    </div>
-</form>
+        <div class="d-flex align-items-center justify-content-end mb-3 gap-2">
+            <a href="{{ route('business-entities.index') }}" class="btn btn-sm btn-outline-dark">Cancel</a>
+            <button type="submit" class="btn btn-sm btn-outline-primary">
+                {{ $isCreating ? 'Create' : 'Update' }}
+            </button>
+        </div>
+    </form>
 @endsection
 
 @push('styles')
-<style>
-    .business-entity-sticky-top {
-        z-index: 900;
-    }
+    <style>
+        .business-entity-sticky-top {
+            z-index: 900;
+        }
 
-    .business-entity-tree,
-    .business-entity-tree ul,
-    .business-entity-tree li {
-        list-style: none;
-        margin: 0;
-        padding-left: 0;
-    }
+        .business-entity-tree,
+        .business-entity-tree ul,
+        .business-entity-tree li {
+            list-style: none;
+            margin: 0;
+            padding-left: 0;
+        }
 
-    .business-entity-tree {
-        min-width: max-content;
-    }
+        .business-entity-tree {
+            min-width: max-content;
+        }
 
-    .business-entity-tree .tree-item {
-        position: relative;
-        margin-bottom: 4px;
-    }
+        .business-entity-tree .tree-item {
+            position: relative;
+            margin-bottom: 4px;
+        }
 
-    .business-entity-tree .tree-item-content {
-        padding: 4px 8px;
-        border-radius: 4px;
-    }
+        .business-entity-tree .tree-item-content {
+            padding: 4px 8px;
+            border-radius: 4px;
+        }
 
-    .business-entity-tree .tree-item-children {
-        margin-left: 25px;
-        margin-top: 4px;
-        position: relative;
-    }
+        .business-entity-tree .tree-item-children {
+            margin-left: 25px;
+            margin-top: 4px;
+            position: relative;
+        }
 
-    .business-entity-tree .tree-item-children::before {
-        content: "";
-        position: absolute;
-        left: 0;
-        top: -4px;
-        bottom: 20px;
-        width: 1px;
-        border-left: 1px solid #adb5bd;
-    }
+        .business-entity-tree .tree-item-children::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: -4px;
+            bottom: 20px;
+            width: 1px;
+            border-left: 1px solid #adb5bd;
+        }
 
-    .business-entity-tree .tree-item-children .tree-item::before {
-        content: "";
-        position: absolute;
-        left: 0;
-        top: 18px;
-        width: 20px;
-        border-top: 1px solid #adb5bd;
-    }
+        .business-entity-tree .tree-item-children .tree-item::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 18px;
+            width: 20px;
+            border-top: 1px solid #adb5bd;
+        }
 
-    .business-entity-tree .tree-item-children .tree-item-content {
-        padding-left: 25px;
-    }
+        .business-entity-tree .tree-item-children .tree-item-content {
+            padding-left: 25px;
+        }
 
-    .business-entity-tree .tree-item-value {
-        color: #6c757d;
-        margin-left: 6px;
-    }
+        .business-entity-tree .tree-item-value {
+            color: #6c757d;
+            margin-left: 6px;
+        }
 
-    .business-entity-tree-header {
-        padding: 4px 8px;
-    }
+        .business-entity-tree-header {
+            padding: 4px 8px;
+        }
 
-    .business-entity-sequence {
-        margin-left: 25px;
-        position: relative;
-    }
+        .business-entity-sequence {
+            margin-left: 25px;
+            position: relative;
+        }
 
-    .business-entity-sequence::before {
-        content: "";
-        position: absolute;
-        left: 0;
-        top: 18px;
-        bottom: 20px;
-        width: 1px;
-        border-left: 1px solid #adb5bd;
-    }
+        .business-entity-sequence::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 18px;
+            bottom: 20px;
+            width: 1px;
+            border-left: 1px solid #adb5bd;
+        }
 
-    .business-entity-sequence > .tree-item::before {
-        content: "";
-        position: absolute;
-        left: 0;
-        top: 18px;
-        width: 20px;
-        border-top: 1px solid #adb5bd;
-    }
+        .business-entity-sequence>.tree-item::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 18px;
+            width: 20px;
+            border-top: 1px solid #adb5bd;
+        }
 
-    .business-entity-sequence > .tree-item > .tree-item-content {
-        padding-left: 25px;
-    }
+        .business-entity-sequence>.tree-item>.tree-item-content {
+            padding-left: 25px;
+        }
 
-    .business-relationship-row {
-        justify-content: flex-start;
-        margin-left: 0;
-    }
-</style>
+        .business-relationship-row {
+            justify-content: flex-start;
+            margin-left: 0;
+        }
+
+        .tooltip-inner {
+            max-width: 350px;
+        }
+    </style>
 @endpush
 
 @push('scripts')
-<script>
-let availableEntities = @json($entityOptions);
-const existingMapping = @json(old('field_mapping') ? json_decode(old('field_mapping'), true) : $fieldMapping);
-const relationshipTypes = [
-    'belongs_to',
-    'has_one',
-    'has_many',
-    'belongs_to_many',
-    'many_to_many',
-    'has_many_through',
-    'morph_one',
-    'morph_many',
-    'morph_to',
-    'morph_to_many',
-    'morphed_by_many',
-    'one_to_one',
-    'one_to_many'
-];
+    <script>
+        let availableEntities = @json($entityOptions);
+        console.log(availableEntities);
+        const existingMapping = @json(old('field_mapping') ? json_decode(old('field_mapping'), true) : $fieldMapping);
+        const relationshipTypes = [
+            'belongs_to',
+            'has_one',
+            'has_many',
+            'belongs_to_many',
+            'many_to_many',
+            'has_many_through',
+            'morph_one',
+            'morph_many',
+            'morph_to',
+            'morph_to_many',
+            'morphed_by_many',
+            'one_to_one',
+            'one_to_many'
+        ];
 
-function findEntity(entityUid) {
-    return availableEntities.find(entity => String(entity.uid) === String(entityUid));
-}
+        function findEntity(entityUid) {
+            return availableEntities.find(entity => String(entity.uid) === String(entityUid));
+        }
 
-function getFieldName(field) {
-    return field.name || field.field || field.meta_key || '';
-}
+        function getFieldName(field) {
+            return field.name || field.field || field.meta_key || '';
+        }
 
-function getFieldLabel(field) {
-    return field.label || getFieldName(field);
-}
+        function getFieldLabel(field) {
+            return field.label || getFieldName(field);
+        }
 
-function getMetaFieldKey(field) {
-    return field.meta_key || field.field || field.name || '';
-}
+        function getMetaFieldKey(field) {
+            return field.meta_key || field.field || field.name || '';
+        }
 
-function getStoredFields(entityMapping) {
-    return entityMapping.fields || entityMapping.selected_fields || [];
-}
+        function getStoredFields(entityMapping) {
+            return entityMapping.fields || entityMapping.selected_fields || [];
+        }
 
-function getStoredMetaFields(entityMapping) {
-    return entityMapping.meta_fields || entityMapping.selected_meta_fields || [];
-}
+        function getStoredMetaFields(entityMapping) {
+            return entityMapping.meta_fields || entityMapping.selected_meta_fields || [];
+        }
 
-function normalizeRelationship(relationship) {
-    return {
-        source_entity: relationship.source_entity || relationship.from_entity || '',
-        target_entity: relationship.target_entity || relationship.to_entity || '',
-        type: relationship.type || relationship.relation_type || '',
-        source_key: relationship.source_key || relationship.from_field || '',
-        target_key: relationship.target_key || relationship.to_field || ''
-    };
-}
+        function normalizeRelationship(relationship) {
+            return {
+                source_entity: relationship.source_entity || relationship.from_entity || '',
+                target_entity: relationship.target_entity || relationship.to_entity || '',
+                type: relationship.type || relationship.relation_type || '',
+                source_key: relationship.source_key || relationship.from_field || '',
+                target_key: relationship.target_key || relationship.to_field || ''
+            };
+        }
 
-function normalizeStoredEntity(entityMapping, index) {
-    const sourceEntity = availableEntities.find(entity => {
-        return String(entity.uid) === String(entityMapping.entity_uid)
-            || String(entity.entity_name) === String(entityMapping.entity);
-    });
+        function normalizeStoredEntity(entityMapping, index) {
+            const sourceEntity = availableEntities.find(entity => {
+                return String(entity.uid) === String(entityMapping.entity_uid) ||
+                    String(entity.entity_name) === String(entityMapping.entity);
+            });
 
-    const entityName = entityMapping.entity || sourceEntity?.entity_name || '';
+            const entityName = entityMapping.entity || sourceEntity?.entity_name || '';
 
-    return {
-        entity_uid: entityMapping.entity_uid || sourceEntity?.uid || '',
-        entity: entityName,
-        slug: entityMapping.slug || sourceEntity?.slug || null,
-        is_primary: Boolean(entityMapping.is_primary),
-        sort_order: entityMapping.sort_order || index + 1,
-        fields: getStoredFields(entityMapping).map(field => ({
-            field: getFieldName(field),
-            label: getFieldLabel(field),
-            type: field.type || '',
-            input_type: field.input_type || null,
-            required: Boolean(field.required),
-            nullable: Boolean(field.nullable),
-            default: field.default ?? null
-        })),
-        meta_fields: getStoredMetaFields(entityMapping).map(field => ({
-            meta_key: getMetaFieldKey(field),
-            label: getFieldLabel(field),
-            type: field.type || '',
-            input_type: field.input_type || null,
-            required: Boolean(field.required),
-            nullable: Boolean(field.nullable),
-            display: field.display ?? true
-        }))
-    };
-}
+            return {
+                entity_uid: entityMapping.entity_uid || sourceEntity?.uid || '',
+                entity: entityName,
+                slug: entityMapping.slug || sourceEntity?.slug || null,
+                is_primary: Boolean(entityMapping.is_primary),
+                is_association: Boolean(entityMapping.is_association),
+                sort_order: entityMapping.sort_order || index + 1,
+                fields: (
+                    entityMapping.is_association ?
+                    (sourceEntity?.fields || []) :
+                    getStoredFields(entityMapping)
+                ).map(field => ({
+                    field: getFieldName(field),
+                    label: getFieldLabel(field),
+                    type: field.type || '',
+                    input_type: field.input_type || null,
+                    required: Boolean(field.required),
+                    nullable: Boolean(field.nullable),
+                    default: field.default ?? null
+                })),
+                meta_fields: getStoredMetaFields(entityMapping).map(field => ({
+                    meta_key: getMetaFieldKey(field),
+                    label: getFieldLabel(field),
+                    type: field.type || '',
+                    input_type: field.input_type || null,
+                    required: Boolean(field.required),
+                    nullable: Boolean(field.nullable),
+                    display: field.display ?? true
+                }))
+            };
+        }
 
-let selectedEntities = Array.isArray(existingMapping.entities)
-    ? existingMapping.entities.map(normalizeStoredEntity)
-    : [];
-let relationships = Array.isArray(existingMapping.relationships)
-    ? existingMapping.relationships.map(normalizeRelationship)
-    : [];
-let openEntityUid = selectedEntities[selectedEntities.length - 1]?.entity_uid || null;
-let submitConfirmedByPreview = false;
+        let selectedEntities = Array.isArray(existingMapping.entities) ?
+            existingMapping.entities.map(normalizeStoredEntity) : [];
+        let relationships = Array.isArray(existingMapping.relationships) ?
+            existingMapping.relationships.map(normalizeRelationship) : [];
+        let openEntityUid = selectedEntities[selectedEntities.length - 1]?.entity_uid || null;
+        let submitConfirmedByPreview = false;
 
-function buildMapping() {
-    return {
-        primary_entity: selectedEntities.find(entity => entity.is_primary)?.entity || null,
-        entities: selectedEntities.map((entity, index) => ({
-            entity_uid: entity.entity_uid,
-            entity: entity.entity,
-            slug: entity.slug,
-            is_primary: entity.is_primary,
-            sort_order: index + 1,
-            fields: entity.fields,
-            meta_fields: entity.meta_fields,
-            relationships: relationships.filter(relationship => {
-                return relationship.source_entity === entity.entity
-                    || relationship.target_entity === entity.entity;
-            })
-        })),
-        relationships: relationships
-    };
-}
+        function buildMapping() {
 
-function syncFieldMappingInput() {
-    document.getElementById('field_mapping').value = JSON.stringify(buildMapping());
-}
+            let generatedRelationships = [...relationships];
 
-function fieldIsSelected(selectedEntity, fieldName) {
-    return (selectedEntity.fields || []).some(field => getFieldName(field) === fieldName);
-}
+            selectedEntities.forEach((entity, index) => {
 
-function metaFieldIsSelected(selectedEntity, metaKey) {
-    return (selectedEntity.meta_fields || []).some(field => getMetaFieldKey(field) === metaKey);
-}
+                const association = selectedEntities[index + 1];
+                const target = selectedEntities[index + 2];
 
-function formatPrimaryField(field) {
-    return {
-        field: getFieldName(field),
-        label: getFieldLabel(field),
-        type: field.type || '',
-        input_type: field.input_type || null,
-        required: Boolean(field.required),
-        nullable: Boolean(field.nullable),
-        default: field.default ?? null
-    };
-}
+                if (
+                    !entity.is_association &&
+                    association?.is_association &&
+                    target &&
+                    !target.is_association
+                ) {
 
-function formatMetaField(field) {
-    return {
-        meta_key: getMetaFieldKey(field),
-        label: getFieldLabel(field),
-        type: field.type || '',
-        input_type: field.input_type || null,
-        required: Boolean(field.required),
-        nullable: Boolean(field.nullable),
-        display: field.display ?? true
-    };
-}
+                    const associationFields =
+                        (association.fields || [])
+                        .map(field => getFieldName(field));
 
-function escapeHtml(value) {
-    return String(value ?? '')
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
-}
+                    const sourceKey =
+                        associationFields.find(field =>
+                            field === `${entity.entity.replace(/s$/, '')}_id`
+                        ) ||
+                        associationFields.find(field =>
+                            field === 'model_id'
+                        );
 
-function getMappingFieldName(field) {
-    return field.field || field.name || field.meta_key || '';
-}
+                    const targetKey =
+                        associationFields.find(field =>
+                            field === `${target.entity.replace(/s$/, '')}_id`
+                        );
 
-function getMappingMetaFieldName(field) {
-    return field.meta_key || field.field || field.name || '';
-}
+                    if (sourceKey && targetKey) {
+                        generatedRelationships = generatedRelationships.filter(
+                            relationship => !(
+                                relationship.source_entity === entity.entity &&
+                                relationship.target_entity === target.entity
+                            )
+                        );
+                        generatedRelationships.push({
+                            type: 'belongs_to_many',
 
-function getDisplayMetaFieldName(field) {
-    const metaFieldName = getMappingMetaFieldName(field);
+                            source_entity: entity.entity,
+                            target_entity: target.entity,
 
-    return metaFieldName.startsWith('m_') ? metaFieldName : `m_${metaFieldName}`;
-}
+                            through: association.entity,
 
-function renderTreeNode(label, value = '', children = '', icon = 'fa-circle') {
-    return `
+                            source_key: 'id',
+                            through_source_key: sourceKey,
+                            through_target_key: targetKey,
+                            target_key: 'id'
+                        });
+                    }
+                }
+            });
+
+            return {
+                primary_entity: selectedEntities.find(entity => entity.is_primary)?.entity || null,
+
+                entities: selectedEntities.map((entity, index) => {
+
+                    const mapping = {
+                        entity_uid: entity.entity_uid,
+                        entity: entity.entity,
+                        slug: entity.slug,
+                        is_primary: entity.is_primary,
+                        is_association: entity.is_association === true,
+                        sort_order: index + 1,
+                        fields: entity.fields
+                    };
+
+                    if (!entity.is_association) {
+                        mapping.meta_fields = entity.meta_fields;
+                    }
+
+                    return mapping;
+                }),
+
+                relationships: generatedRelationships
+            };
+        }
+
+        function syncFieldMappingInput() {
+            document.getElementById('field_mapping').value = JSON.stringify(buildMapping());
+        }
+
+        function fieldIsSelected(selectedEntity, fieldName) {
+            return (selectedEntity.fields || []).some(field => getFieldName(field) === fieldName);
+        }
+
+        function metaFieldIsSelected(selectedEntity, metaKey) {
+            return (selectedEntity.meta_fields || []).some(field => getMetaFieldKey(field) === metaKey);
+        }
+
+        function formatPrimaryField(field) {
+            return {
+                field: getFieldName(field),
+                label: getFieldLabel(field),
+                type: field.type || '',
+                input_type: field.input_type || null,
+                required: Boolean(field.required),
+                nullable: Boolean(field.nullable),
+                default: field.default ?? null
+            };
+        }
+
+        function formatMetaField(field) {
+            return {
+                meta_key: getMetaFieldKey(field),
+                label: getFieldLabel(field),
+                type: field.type || '',
+                input_type: field.input_type || null,
+                required: Boolean(field.required),
+                nullable: Boolean(field.nullable),
+                display: field.display ?? true
+            };
+        }
+
+        function escapeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        function getMappingFieldName(field) {
+            return field.field || field.name || field.meta_key || '';
+        }
+
+        function getMappingMetaFieldName(field) {
+            return field.meta_key || field.field || field.name || '';
+        }
+
+        function getDisplayMetaFieldName(field) {
+            const metaFieldName = getMappingMetaFieldName(field);
+
+            return metaFieldName.startsWith('m_') ? metaFieldName : `m_${metaFieldName}`;
+        }
+
+        function renderTreeNode(label, value = '', children = '', icon = 'fa-circle') {
+            return `
         <li class="tree-item">
             <div class="tree-item-content">
                 <i class="fas fa-fw ${icon} text-muted me-1"></i>
@@ -428,95 +507,121 @@ function renderTreeNode(label, value = '', children = '', icon = 'fa-circle') {
             ${children ? `<ul class="tree-item-children">${children}</ul>` : ''}
         </li>
     `;
-}
-
-function renderFieldTree(fields, emptyLabel) {
-    if (!fields.length) {
-        return renderTreeNode(emptyLabel, '', '', 'fa-minus');
-    }
-
-    return fields.map(field => renderTreeNode(
-        getMappingFieldName(field),
-        [field.label, field.type].filter(Boolean).join(' | '),
-        '',
-        'fa-table-columns'
-    )).join('');
-}
-
-function renderMetaFieldTree(fields) {
-    return fields.map(field => renderTreeNode(
-        getDisplayMetaFieldName(field),
-        [field.label, field.type].filter(Boolean).join(' | '),
-        '',
-        'fa-tags'
-    )).join('');
-}
-
-function findRelationshipsBetween(sourceEntity, targetEntity, mappingRelationships) {
-    return mappingRelationships.filter(relationship => {
-        return (
-            relationship.source_entity === sourceEntity.entity
-            && relationship.target_entity === targetEntity.entity
-        ) || (
-            relationship.source_entity === targetEntity.entity
-            && relationship.target_entity === sourceEntity.entity
-        );
-    });
-}
-
-function renderRelationshipConnector(sourceEntity, targetEntity, mappingRelationships) {
-    const matchingRelationships = findRelationshipsBetween(sourceEntity, targetEntity, mappingRelationships);
-
-    if (!matchingRelationships.length) {
-        return renderTreeNode(
-            `${sourceEntity.entity || 'source'} -> ${targetEntity.entity || 'target'}`,
-            'No relationship configured',
-            '',
-            'fa-link'
-        );
-    }
-
-    return matchingRelationships.map(relationship => {
-        const relationLabel = `${relationship.source_entity || 'source'} -> ${relationship.target_entity || 'target'}`;
-        const relationValue = [
-            relationship.type,
-            relationship.source_key && relationship.target_key
-                ? `${relationship.source_key} -> ${relationship.target_key}`
-                : ''
-        ].filter(Boolean).join(' | ');
-
-        return renderTreeNode(relationLabel, relationValue, '', 'fa-link');
-    }).join('');
-}
-
-function renderBusinessEntityTree(mapping) {
-    const mappingRelationships = mapping.relationships || [];
-    const entityNodes = (mapping.entities || []).map((entity, index) => {
-        const entityFields = [
-            renderFieldTree(entity.fields || [], 'No fields selected'),
-            renderMetaFieldTree(entity.meta_fields || [])
-        ].join('');
-        const entityNode = renderTreeNode(
-            entity.entity || 'Unnamed entity',
-            entity.is_primary ? 'Primary' : '',
-            entityFields || renderTreeNode('No fields selected', '', '', 'fa-minus'),
-            entity.is_primary ? 'fa-star' : 'fa-table'
-        );
-        const nextEntity = (mapping.entities || [])[index + 1];
-
-        if (!nextEntity) {
-            return entityNode;
         }
 
-        return entityNode + renderTreeNode(
-            'Relationship',
-            '',
-            renderRelationshipConnector(entity, nextEntity, mappingRelationships),
-            'fa-diagram-project'
-        );
-    }).join('');
+        function renderFieldTree(fields, emptyLabel) {
+            if (!fields.length) {
+                return renderTreeNode(emptyLabel, '', '', 'fa-minus');
+            }
 
-    return `
+            return fields.map(field => renderTreeNode(
+                getMappingFieldName(field),
+                [field.label, field.type].filter(Boolean).join(' | '),
+                '',
+                'fa-table-columns'
+            )).join('');
+        }
+
+        function renderMetaFieldTree(fields) {
+            return fields.map(field => renderTreeNode(
+                getDisplayMetaFieldName(field),
+                [field.label, field.type].filter(Boolean).join(' | '),
+                '',
+                'fa-tags'
+            )).join('');
+        }
+
+        function findRelationshipsBetween(sourceEntity, targetEntity, mappingRelationships) {
+            return mappingRelationships.filter(relationship => {
+                return (
+                    relationship.source_entity === sourceEntity.entity &&
+                    relationship.target_entity === targetEntity.entity
+                ) || (
+                    relationship.source_entity === targetEntity.entity &&
+                    relationship.target_entity === sourceEntity.entity
+                );
+            });
+        }
+
+        function renderRelationshipConnector(sourceEntity, targetEntity, mappingRelationships) {
+            const matchingRelationships = findRelationshipsBetween(sourceEntity, targetEntity, mappingRelationships);
+
+            if (!matchingRelationships.length) {
+                return renderTreeNode(
+                    `${sourceEntity.entity || 'source'} -> ${targetEntity.entity || 'target'}`,
+                    'No relationship configured',
+                    '',
+                    'fa-link'
+                );
+            }
+
+            return matchingRelationships.map(relationship => {
+                const relationLabel =
+                    `${relationship.source_entity || 'source'} -> ${relationship.target_entity || 'target'}`;
+                const relationValue = [
+                    relationship.type,
+                    relationship.source_key && relationship.target_key ?
+                    `${relationship.source_key} -> ${relationship.target_key}` :
+                    ''
+                ].filter(Boolean).join(' | ');
+
+                return renderTreeNode(relationLabel, relationValue, '', 'fa-link');
+            }).join('');
+        }
+
+        function renderAssociationConnector(associationEntity) {
+
+            return renderTreeNode(
+                `Association: ${associationEntity.entity}`,
+                '',
+                renderFieldTree(
+                    associationEntity.fields || [],
+                    'No fields available'
+                ),
+                'fa-link'
+            );
+        }
+
+        function renderBusinessEntityTree(mapping) {
+            const mappingRelationships = mapping.relationships || [];
+            const entityNodes = (mapping.entities || []).map((entity, index) => {
+                if (entity.is_association) {
+                    return '';
+                }
+                const entityFields = [
+                    renderFieldTree(entity.fields || [], 'No fields selected'),
+                    renderMetaFieldTree(entity.meta_fields || [])
+                ].join('');
+                const entityNode = renderTreeNode(
+                    entity.entity || 'Unnamed entity',
+                    entity.is_primary ? 'Primary' : '',
+                    entityFields || renderTreeNode('No fields selected', '', '', 'fa-minus'),
+                    entity.is_primary ? 'fa-star' : 'fa-table'
+                );
+                const nextEntity = (mapping.entities || [])[index + 1];
+
+                if (!nextEntity) {
+                    return entityNode;
+                }
+
+                if (nextEntity.is_association) {
+                    return entityNode +
+                        renderAssociationConnector(nextEntity);
+                }
+
+                return entityNode + renderTreeNode(
+                    'Relationship',
+                    '',
+                    renderRelationshipConnector(
+                        entity,
+                        nextEntity,
+                        mappingRelationships
+                    ),
+                    'fa-diagram-project'
+                );
+            }).join('');
+
+            return `
         <div class="overflow-auto bg-light border rounded p-2" style="max-height: 60vh;">
             <div class="business-entity-tree-header">
                 <i class="fas fa-fw fa-sitemap text-muted me-1"></i>
@@ -528,82 +633,110 @@ function renderBusinessEntityTree(mapping) {
             </ul>
         </div>
     `;
-}
+        }
 
-function showBusinessEntityPreviewModal(options = {}) {
-    syncFieldMappingInput();
-    const mapping = buildMapping();
-    const modalBody = document.createElement('div');
-    modalBody.innerHTML = renderBusinessEntityTree(mapping);
-    const actions = [];
+        function showBusinessEntityPreviewModal(options = {}) {
+            syncFieldMappingInput();
+            const mapping = buildMapping();
+            const modalBody = document.createElement('div');
+            modalBody.innerHTML = renderBusinessEntityTree(mapping);
+            const actions = [];
 
-    if (typeof options.onConfirm === 'function') {
-        actions.push({
-            id: 'confirmBusinessEntitySave',
-            label: options.confirmLabel || 'Continue',
-            className: 'btn btn-primary',
-            action: options.onConfirm
-        });
-    }
+            if (typeof options.onConfirm === 'function') {
+                actions.push({
+                    id: 'confirmBusinessEntitySave',
+                    label: options.confirmLabel || 'Continue',
+                    className: 'btn btn-primary',
+                    action: options.onConfirm
+                });
+            }
 
-    showModal({
-        header: {
-            enabled: true,
-            content: `
+            showModal({
+                header: {
+                    enabled: true,
+                    content: `
                 <h5 class="modal-title">${escapeHtml(options.title || 'Business Entity Mapping')}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             `,
-        },
-        body: {
-            enabled: true,
-            content: modalBody,
-        },
-        footer: {
-            enabled: true,
-            allowCancel: true,
-            actions: actions,
-        },
-    });
-}
+                },
+                body: {
+                    enabled: true,
+                    content: modalBody,
+                },
+                footer: {
+                    enabled: true,
+                    allowCancel: true,
+                    actions: actions,
+                },
+            });
+        }
 
-function getEntityKeyOptions(entityUid) {
-    const entity = findEntity(entityUid);
-    const primaryKeys = (entity?.fields || []).map(getFieldName).filter(Boolean);
-    const metaKeys = (entity?.meta_fields || []).map(getMetaFieldKey).filter(Boolean);
+        function getEntityKeyOptions(entityUid) {
+            const entity = findEntity(entityUid);
+            const primaryKeys = (entity?.fields || []).map(getFieldName).filter(Boolean);
+            const metaKeys = (entity?.meta_fields || []).map(getMetaFieldKey).filter(Boolean);
 
-    return [...new Set([...primaryKeys, ...metaKeys])];
-}
+            return [...new Set([...primaryKeys, ...metaKeys])];
+        }
 
-function getUnselectedEntities() {
-    const selectedUids = selectedEntities.map(entity => String(entity.entity_uid));
+        function getUnselectedEntities() {
+            const selectedUids = selectedEntities.map(entity => String(entity.entity_uid));
 
-    return availableEntities.filter(entity => !selectedUids.includes(String(entity.uid)));
-}
+            return availableEntities.filter(entity => !selectedUids.includes(String(entity.uid)));
+        }
 
-function getRelationshipBetween(sourceEntity, targetEntity) {
-    return relationships.find(relationship => {
-        return relationship.source_entity === sourceEntity.entity
-            && relationship.target_entity === targetEntity.entity;
-    });
-}
+        function getUnselectedNormalEntities() {
+            const selectedUids = selectedEntities.map(entity => String(entity.entity_uid));
 
-function removeRelationshipsForEntity(entityName) {
-    relationships = relationships.filter(relationship => {
-        return relationship.source_entity !== entityName
-            && relationship.target_entity !== entityName;
-    });
-}
+            return availableEntities.filter(entity =>
+                !entity.is_pivot &&
+                !selectedUids.includes(String(entity.uid))
+            );
+        }
 
-function renderRelationshipButton(sourceEntity, targetEntity, sourceIndex) {
-    const relationship = getRelationshipBetween(sourceEntity, targetEntity);
-    const label = relationship
-        ? `${escapeHtml(relationship.type)}: ${escapeHtml(relationship.source_key || 'source')} -> ${escapeHtml(relationship.target_key || 'target')}`
-        : 'Relationship';
+        function getUnselectedAssociationEntities() {
+            const selectedUids = selectedEntities.map(entity => String(entity.entity_uid));
 
-    return `
+            return availableEntities.filter(entity =>
+                entity.is_pivot &&
+                !selectedUids.includes(String(entity.uid))
+            );
+        }
+
+        function findLastNonAssociationIndex() {
+            for (let i = selectedEntities.length - 1; i >= 0; i--) {
+                if (!selectedEntities[i].is_association) {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        function getRelationshipBetween(sourceEntity, targetEntity) {
+            return relationships.find(relationship => {
+                return relationship.source_entity === sourceEntity.entity &&
+                    relationship.target_entity === targetEntity.entity;
+            });
+        }
+
+        function removeRelationshipsForEntity(entityName) {
+            relationships = relationships.filter(relationship => {
+                return relationship.source_entity !== entityName &&
+                    relationship.target_entity !== entityName;
+            });
+        }
+
+        function renderRelationshipButton(sourceEntity, targetEntity, sourceIndex) {
+            const relationship = getRelationshipBetween(sourceEntity, targetEntity);
+            const label = relationship ?
+                `${escapeHtml(relationship.type)}: ${escapeHtml(relationship.source_key || 'source')} -> ${escapeHtml(relationship.target_key || 'target')}` :
+                'Relationship';
+
+            return `
         <div class="d-flex align-items-center gap-2 my-2 business-relationship-row">
             <button type="button"
-                class="btn btn-sm ${relationship ? 'btn-outline-success' : 'btn-outline-secondary'} edit-business-relationship"
+                class="btn btn-link p-0 text-decoration-none edit-business-relationship"
                 data-source-index="${sourceIndex}"
                 data-target-index="${sourceIndex + 1}">
                 <i class="fa-solid fa-fw fa-link"></i>
@@ -611,19 +744,19 @@ function renderRelationshipButton(sourceEntity, targetEntity, sourceIndex) {
             </button>
         </div>
     `;
-}
+        }
 
-function renderFieldRows(selectedEntity, sourceEntity, entityIndex) {
-    const fields = sourceEntity?.fields || [];
+        function renderFieldRows(selectedEntity, sourceEntity, entityIndex) {
+            const fields = sourceEntity?.fields || [];
 
-    if (!fields.length) {
-        return '<tr><td colspan="7" class="text-center text-muted">No primary fields available.</td></tr>';
-    }
+            if (!fields.length) {
+                return '<tr><td colspan="7" class="text-center text-muted">No primary fields available.</td></tr>';
+            }
 
-    return fields.map(field => {
-        const fieldName = getFieldName(field);
+            return fields.map(field => {
+                const fieldName = getFieldName(field);
 
-        return `
+                return `
             <tr>
                 <td>
                     <input type="checkbox" class="form-check-input business-primary-field-check"
@@ -639,20 +772,39 @@ function renderFieldRows(selectedEntity, sourceEntity, entityIndex) {
                 <td>${escapeHtml(field.input_type || '')}</td>
             </tr>
         `;
-    }).join('');
-}
+            }).join('');
+        }
 
-function renderMetaFieldRows(selectedEntity, sourceEntity, entityIndex) {
-    const metaFields = sourceEntity?.meta_fields || [];
+        function renderAssociationFieldRows(sourceEntity) {
+            const fields = sourceEntity?.fields || [];
 
-    if (!metaFields.length) {
-        return '<tr><td colspan="7" class="text-center text-muted">No meta fields available.</td></tr>';
-    }
+            if (!fields.length) {
+                return '<tr><td colspan="6" class="text-center text-muted">No fields available.</td></tr>';
+            }
 
-    return metaFields.map(field => {
-        const metaKey = getMetaFieldKey(field);
+            return fields.map(field => `
+                <tr>
+                    <td>${escapeHtml(getFieldName(field))}</td>
+                    <td>${escapeHtml(field.type || '')}</td>
+                    <td>${escapeHtml(getFieldLabel(field))}</td>
+                    <td>${field.required ? 'Yes' : 'No'}</td>
+                    <td>${field.nullable ? 'Yes' : 'No'}</td>
+                    <td>${escapeHtml(field.input_type || '')}</td>
+                </tr>
+            `).join('');
+        }
 
-        return `
+        function renderMetaFieldRows(selectedEntity, sourceEntity, entityIndex) {
+            const metaFields = sourceEntity?.meta_fields || [];
+
+            if (!metaFields.length) {
+                return '<tr><td colspan="7" class="text-center text-muted">No meta fields available.</td></tr>';
+            }
+
+            return metaFields.map(field => {
+                const metaKey = getMetaFieldKey(field);
+
+                return `
             <tr>
                 <td>
                     <input type="checkbox" class="form-check-input business-meta-field-check"
@@ -668,39 +820,55 @@ function renderMetaFieldRows(selectedEntity, sourceEntity, entityIndex) {
                 <td>${escapeHtml(field.input_type || '')}</td>
             </tr>
         `;
-    }).join('');
-}
+            }).join('');
+        }
 
-function renderSelectedEntities() {
-    const wrapper = document.getElementById('selectedEntityPanels');
-    const primaryAddButton = document.getElementById('primaryAddBusinessEntityItem');
-    const hasUnselectedEntities = getUnselectedEntities().length > 0;
+        function renderSelectedEntities() {
+            const wrapper = document.getElementById('selectedEntityPanels');
+            const primaryAddButton = document.getElementById('primaryAddBusinessEntityItem');
+            const hasUnselectedEntities =
+                getUnselectedNormalEntities().length > 0;
 
-    if (primaryAddButton) {
-        primaryAddButton.disabled = !hasUnselectedEntities;
-    }
+            const hasUnselectedAssociations =
+                getUnselectedAssociationEntities().length > 0;
 
-    wrapper.innerHTML = '';
+            if (primaryAddButton) {
+                primaryAddButton.disabled = !hasUnselectedEntities;
+            }
 
-    if (!selectedEntities.length) {
-        wrapper.innerHTML = '<div class="text-center text-muted border rounded p-3">No entities added.</div>';
-        syncFieldMappingInput();
-        return;
-    }
+            const associationButton =
+                document.getElementById('primaryAddAssociationItem');
 
-    wrapper.insertAdjacentHTML('beforeend', '<div class="accordion" id="businessEntityItemsAccordion"></div>');
-    const accordion = document.getElementById('businessEntityItemsAccordion');
+            if (associationButton) {
+                associationButton.disabled = !hasUnselectedAssociations;
+            }
 
-    selectedEntities.forEach((selectedEntity, entityIndex) => {
-        const sourceEntity = findEntity(selectedEntity.entity_uid);
-        const selectedCount = (selectedEntity.fields || []).length + (selectedEntity.meta_fields || []).length;
-        const collapseId = `businessEntityItem${entityIndex}`;
-        const headerId = `businessEntityItemHeader${entityIndex}`;
-        const isOpen = openEntityUid
-            ? selectedEntity.entity_uid === openEntityUid
-            : entityIndex === selectedEntities.length - 1;
+            wrapper.innerHTML = '';
 
-        accordion.insertAdjacentHTML('beforeend', `
+            if (!selectedEntities.length) {
+                wrapper.innerHTML = '<div class="text-center text-muted border rounded p-3">No entities added.</div>';
+                syncFieldMappingInput();
+                return;
+            }
+
+            wrapper.insertAdjacentHTML('beforeend', '<div class="accordion" id="businessEntityItemsAccordion"></div>');
+            const accordion = document.getElementById('businessEntityItemsAccordion');
+
+            selectedEntities.forEach((selectedEntity, entityIndex) => {
+                const sourceEntity = findEntity(selectedEntity.entity_uid);
+                const selectedCount = (selectedEntity.fields || []).length + (selectedEntity.meta_fields || [])
+                    .length;
+                const selectedCountLabel = selectedEntity.is_association ?
+                    '' :
+                    `<span class="text-muted ms-2">${selectedCount} selected fields</span>`;
+                const collapseId = `businessEntityItem${entityIndex}`;
+                const headerId = `businessEntityItemHeader${entityIndex}`;
+                const isOpen = openEntityUid ?
+                    selectedEntity.entity_uid === openEntityUid :
+                    entityIndex === selectedEntities.length - 1;
+                const isAssociation = selectedEntity.is_association === true;
+
+                accordion.insertAdjacentHTML('beforeend', `
             <div class="accordion-item mb-2 border rounded">
                 <h2 class="accordion-header" id="${headerId}">
                     <div class="d-flex align-items-center bg-light">
@@ -712,8 +880,17 @@ function renderSelectedEntities() {
                             aria-expanded="${isOpen ? 'true' : 'false'}"
                             aria-controls="${collapseId}">
                             <strong>${escapeHtml(selectedEntity.entity)}</strong>
-                            <span class="text-muted ms-2">${selectedCount} selected fields</span>
-                            ${selectedEntity.is_primary ? '<span class="badge bg-primary ms-2">Primary</span>' : ''}
+                            ${selectedCountLabel}
+
+                            ${selectedEntity.is_primary
+                                ? '<span class="badge bg-primary ms-2">Primary</span>'
+                                : ''
+                            }
+
+                            ${selectedEntity.is_association
+                                ? '<span class="badge bg-secondary ms-2">Association</span>'
+                                : ''
+                            }
                         </button>
                         <button type="button" class="btn btn-sm btn-outline-danger me-3 remove-business-entity-item" data-entity-index="${entityIndex}">
                             <i class="fas fa-fw fa-trash"></i>
@@ -723,180 +900,324 @@ function renderSelectedEntities() {
 
                 <div id="${collapseId}" class="accordion-collapse collapse ${isOpen ? 'show' : ''}" aria-labelledby="${headerId}">
                     <div class="accordion-body p-3">
-                        <h6 class="text-primary">Primary Fields</h6>
-                        <div class="table-responsive mb-3">
-                            <table class="table table-sm table-bordered mb-0">
-                                <thead>
-                                    <tr>
-                                        <th style="width: 70px;">#</th>
-                                        <th>Field</th>
-                                        <th>Type</th>
-                                        <th>Label</th>
-                                        <th>Required</th>
-                                        <th>Nullable</th>
-                                        <th>Input</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    ${renderFieldRows(selectedEntity, sourceEntity, entityIndex)}
-                                </tbody>
-                            </table>
-                        </div>
 
-                        <h6 class="text-success">Meta Fields</h6>
-                        <div class="table-responsive">
-                            <table class="table table-sm table-bordered mb-0">
-                                <thead>
-                                    <tr>
-                                        <th style="width: 70px;">#</th>
-                                        <th>Meta Key</th>
-                                        <th>Type</th>
-                                        <th>Label</th>
-                                        <th>Required</th>
-                                        <th>Nullable</th>
-                                        <th>Input</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    ${renderMetaFieldRows(selectedEntity, sourceEntity, entityIndex)}
-                                </tbody>
-                            </table>
-                        </div>
+                    ${isAssociation ? `
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-bordered mb-0">
+                                        <thead>
+                                            <tr>
+                                                <th>Field</th>
+                                                <th>Type</th>
+                                                <th>Label</th>
+                                                <th>Required</th>
+                                                <th>Nullable</th>
+                                                <th>Input</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            ${renderAssociationFieldRows(sourceEntity)}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            ` : `
+
+                                        <h6 class="text-primary">Primary Fields</h6>
+                                        <div class="table-responsive mb-3">
+                                            <table class="table table-sm table-bordered mb-0">
+                                                <thead>
+                                                    <tr>
+                                                        <th style="width: 70px;">#</th>
+                                                        <th>Field</th>
+                                                        <th>Type</th>
+                                                        <th>Label</th>
+                                                        <th>Required</th>
+                                                        <th>Nullable</th>
+                                                        <th>Input</th>
+                                                    </tr>
+                                                </thead>
+                                                    <tbody>
+                                                        ${renderFieldRows(selectedEntity, sourceEntity, entityIndex)}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <h6 class="text-success">Meta Fields</h6>
+                                            <div class="table-responsive">
+                                                <table class="table table-sm table-bordered mb-0">
+                                                    <thead>
+                                                        <tr>
+                                                            <th style="width: 70px;">#</th>
+                                                            <th>Meta Key</th>
+                                                            <th>Type</th>
+                                                            <th>Label</th>
+                                                            <th>Required</th>
+                                                            <th>Nullable</th>
+                                                            <th>Input</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        ${renderMetaFieldRows(selectedEntity, sourceEntity, entityIndex)}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                        `}
+
                     </div>
                 </div>
             </div>
         `);
 
-        if (selectedEntities[entityIndex + 1]) {
-            accordion.insertAdjacentHTML('beforeend', renderRelationshipButton(
-                selectedEntity,
-                selectedEntities[entityIndex + 1],
-                entityIndex
-            ));
+                const nextEntity = selectedEntities[entityIndex + 1];
+
+                if (
+                    nextEntity &&
+                    !selectedEntity.is_association &&
+                    !nextEntity.is_association
+                ) {
+                    accordion.insertAdjacentHTML(
+                        'beforeend',
+                        renderRelationshipButton(
+                            selectedEntity,
+                            nextEntity,
+                            entityIndex
+                        )
+                    );
+                }
+            });
+
+            syncFieldMappingInput();
         }
-    });
 
-    syncFieldMappingInput();
-}
-
-function showAddEntityModal() {
-    const modalBody = document.createElement('div');
-    modalBody.innerHTML = `
+        function showAddEntityModal() {
+            const modalBody = document.createElement('div');
+            modalBody.innerHTML = `
         <div class="row g-3">
             <div class="col-12">
                 <label for="modalEntitySelector" class="form-label">Entity / Table</label>
                 <select id="modalEntitySelector" class="form-select">
                     <option value="">- Select Entity -</option>
-                    ${availableEntities.map(entity => {
-                        const isSelected = selectedEntities.some(selectedEntity => {
-                            return String(selectedEntity.entity_uid) === String(entity.uid);
-                        });
 
-                        return `
-                            <option value="${escapeHtml(entity.uid)}" ${isSelected ? 'disabled' : ''}>
-                                ${escapeHtml(entity.entity_name)}${isSelected ? ' (already selected)' : ''}
-                            </option>
-                        `;
-                    }).join('')}
+                    ${getUnselectedNormalEntities().map(entity => `
+                                                            <option value="${escapeHtml(entity.uid)}">
+                                                                ${escapeHtml(entity.entity_name)}
+                                                            </option>
+                                                    `).join('')}
                 </select>
             </div>
             <div class="col-12">
                 <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="modalEntityPrimary" ${selectedEntities.length === 0 ? 'checked disabled' : ''}>
-                    <label class="form-check-label" for="modalEntityPrimary">Primary</label>
+                    <input class="form-check-input"
+                        type="checkbox"
+                        id="modalEntityPrimary"
+                        ${selectedEntities.length === 0 ? 'checked disabled' : 'disabled'}
+                        title="The Primary Entity serves as the root entity for this Business Entity. The first entity added is automatically set as Primary to ensure a clear and consistent hierarchy.">
+                    <label class="form-check-label" for="modalEntityPrimary">
+                        Primary
+
+                        ${selectedEntities.length > 0 ? `
+                                        <i class="fa-solid fa-circle-info text-muted ms-1"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="right"
+                                        data-bs-html="true"
+                                        title="<strong>Primary Entity</strong><br>The first entity added becomes the Primary Entity. It acts as the root of the Business Entity hierarchy and cannot be changed later.">
+                                        </i>
+                                    ` : ''}
+                    </label>
                 </div>
             </div>
         </div>
     `;
 
-    showModal({
-        header: {
-            enabled: true,
-            content: `
+            showModal({
+                header: {
+                    enabled: true,
+                    content: `
                 <h5 class="modal-title">Add Entity</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             `,
-        },
-        body: {
-            enabled: true,
-            content: modalBody,
-        },
-        footer: {
-            enabled: true,
-            allowCancel: true,
-            actions: [
-                {
-                    id: 'confirmBusinessEntityItem',
-                    label: 'Add Entity',
-                    className: 'btn btn-primary',
-                    action: function() {
-                        addSelectedEntityFromModal();
-                    }
-                }
-            ],
-        },
-    });
-}
+                },
+                body: {
+                    enabled: true,
+                    content: modalBody,
+                },
+                footer: {
+                    enabled: true,
+                    allowCancel: true,
+                    actions: [{
+                        id: 'confirmBusinessEntityItem',
+                        label: 'Add Entity',
+                        className: 'btn btn-primary',
+                        action: function() {
+                            addSelectedEntityFromModal();
+                        }
+                    }],
+                },
+            });
 
-function addSelectedEntityFromModal() {
-    const selector = document.getElementById('modalEntitySelector');
-    const primaryInput = document.getElementById('modalEntityPrimary');
-    const entity = findEntity(selector?.value);
+            setTimeout(() => {
+                document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+                    bootstrap.Tooltip.getOrCreateInstance(el);
+                });
+            }, 100);
+        }
 
-    if (!entity) {
-        return;
-    }
+        function showAddAssociationModal() {
+            const modalBody = document.createElement('div');
 
-    if (selectedEntities.some(selectedEntity => String(selectedEntity.entity_uid) === String(entity.uid))) {
-        return;
-    }
+            modalBody.innerHTML = `
+        <div class="row g-3">
+            <div class="col-12">
+                <label for="modalAssociationSelector" class="form-label">Association Table</label>
+                <select id="modalAssociationSelector" class="form-select">
+                    <option value="">- Select Association -</option>
 
-    const isPrimary = primaryInput?.checked || selectedEntities.length === 0;
+                    ${getUnselectedAssociationEntities().map(entity => `
+                                                        <option value="${escapeHtml(entity.uid)}">
+                                                            ${escapeHtml(entity.entity_name)}
+                                                        </option>
+                                                    `).join('')}
+                </select>
+            </div>
+        </div>
+    `;
 
-    if (isPrimary) {
-        selectedEntities = selectedEntities.map(selectedEntity => ({
-            ...selectedEntity,
-            is_primary: false
-        }));
-    }
+            showModal({
+                header: {
+                    enabled: true,
+                    content: `
+                <h5 class="modal-title">Add Association</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            `,
+                },
+                body: {
+                    enabled: true,
+                    content: modalBody,
+                },
+                footer: {
+                    enabled: true,
+                    allowCancel: true,
+                    actions: [{
+                        id: 'confirmAssociationItem',
+                        label: 'Add Association',
+                        className: 'btn btn-primary',
+                        action: function() {
+                            addSelectedAssociationFromModal();
+                        }
+                    }],
+                },
+            });
+        }
 
-    const newSelectedEntity = {
-        entity_uid: entity.uid,
-        entity: entity.entity_name,
-        slug: entity.slug,
-        is_primary: isPrimary,
-        sort_order: selectedEntities.length + 1,
-        fields: [],
-        meta_fields: []
-    };
+        function addSelectedAssociationFromModal() {
+            const selector = document.getElementById('modalAssociationSelector');
+            const entity = findEntity(selector?.value);
 
-    selectedEntities.push(newSelectedEntity);
+            if (!entity) {
+                return;
+            }
 
-    selectedEntities = selectedEntities.map((selectedEntity, index) => ({
-        ...selectedEntity,
-        sort_order: index + 1
-    }));
+            if (selectedEntities.some(selectedEntity =>
+                    String(selectedEntity.entity_uid) === String(entity.uid)
+                )) {
+                return;
+            }
 
-    openEntityUid = entity.uid;
+            const associationEntity = {
+                entity_uid: entity.uid,
+                entity: entity.entity_name,
+                slug: entity.slug,
+                is_primary: false,
+                is_association: true,
+                sort_order: selectedEntities.length + 1,
 
-    bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
-    renderSelectedEntities();
-}
+                fields: (entity.fields || []).map(field => ({
+                    field: getFieldName(field),
+                    label: getFieldLabel(field),
+                    type: field.type || '',
+                    input_type: field.input_type || null,
+                    required: Boolean(field.required),
+                    nullable: Boolean(field.nullable),
+                    default: field.default ?? null
+                })),
 
-function showRelationshipModal(sourceIndex, targetIndex) {
-    const sourceEntity = selectedEntities[sourceIndex];
-    const targetEntity = selectedEntities[targetIndex];
+                meta_fields: []
+            };
 
-    if (!sourceEntity || !targetEntity) {
-        return;
-    }
+            const insertIndex = findLastNonAssociationIndex();
 
-    const existingRelationship = getRelationshipBetween(sourceEntity, targetEntity) || {};
-    const sourceKeyOptions = getEntityKeyOptions(sourceEntity.entity_uid);
-    const targetKeyOptions = getEntityKeyOptions(targetEntity.entity_uid);
-    const modalBody = document.createElement('div');
+            if (insertIndex === -1) {
+                selectedEntities.push(associationEntity);
+            } else {
+                selectedEntities.splice(insertIndex + 1, 0, associationEntity);
+            }
 
-    modalBody.innerHTML = `
+            selectedEntities = selectedEntities.map((selectedEntity, index) => ({
+                ...selectedEntity,
+                sort_order: index + 1
+            }));
+
+            openEntityUid = entity.uid;
+
+            bootstrap.Modal.getInstance(
+                document.getElementById('labModal')
+            )?.hide();
+
+            renderSelectedEntities();
+        }
+
+        function addSelectedEntityFromModal() {
+            const selector = document.getElementById('modalEntitySelector');
+            const primaryInput = document.getElementById('modalEntityPrimary');
+            const entity = findEntity(selector?.value);
+
+            if (!entity) {
+                return;
+            }
+
+            if (selectedEntities.some(selectedEntity => String(selectedEntity.entity_uid) === String(entity.uid))) {
+                return;
+            }
+
+            const isPrimary = selectedEntities.length === 0;
+
+            const newSelectedEntity = {
+                entity_uid: entity.uid,
+                entity: entity.entity_name,
+                slug: entity.slug,
+                is_primary: isPrimary,
+                sort_order: selectedEntities.length + 1,
+                fields: [],
+                meta_fields: []
+            };
+
+            selectedEntities.push(newSelectedEntity);
+
+            selectedEntities = selectedEntities.map((selectedEntity, index) => ({
+                ...selectedEntity,
+                sort_order: index + 1
+            }));
+
+            openEntityUid = entity.uid;
+
+            bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
+            renderSelectedEntities();
+        }
+
+        function showRelationshipModal(sourceIndex, targetIndex) {
+            const sourceEntity = selectedEntities[sourceIndex];
+            const targetEntity = selectedEntities[targetIndex];
+
+            if (!sourceEntity || !targetEntity) {
+                return;
+            }
+
+            const existingRelationship = getRelationshipBetween(sourceEntity, targetEntity) || {};
+            const sourceKeyOptions = getEntityKeyOptions(sourceEntity.entity_uid);
+            const targetKeyOptions = getEntityKeyOptions(targetEntity.entity_uid);
+            const modalBody = document.createElement('div');
+
+            modalBody.innerHTML = `
         <div class="row g-3">
             <div class="col-md-6">
                 <label class="form-label">Source Entity</label>
@@ -911,10 +1232,10 @@ function showRelationshipModal(sourceIndex, targetIndex) {
                 <select id="relationshipType" class="form-select">
                     <option value="">- Select Type -</option>
                     ${relationshipTypes.map(type => `
-                        <option value="${escapeHtml(type)}" ${existingRelationship.type === type ? 'selected' : ''}>
-                            ${escapeHtml(type.replace(/_/g, ' '))}
-                        </option>
-                    `).join('')}
+                                                                                                    <option value="${escapeHtml(type)}" ${existingRelationship.type === type ? 'selected' : ''}>
+                                                                                                        ${escapeHtml(type.replace(/_/g, ' '))}
+                                                                                                    </option>
+                                                                                                `).join('')}
                 </select>
             </div>
             <div class="col-md-4">
@@ -922,10 +1243,10 @@ function showRelationshipModal(sourceIndex, targetIndex) {
                 <select id="relationshipSourceKey" class="form-select">
                     <option value="">- Select Source Key -</option>
                     ${sourceKeyOptions.map(key => `
-                        <option value="${escapeHtml(key)}" ${existingRelationship.source_key === key ? 'selected' : ''}>
-                            ${escapeHtml(key)}
-                        </option>
-                    `).join('')}
+                                                                                                    <option value="${escapeHtml(key)}" ${existingRelationship.source_key === key ? 'selected' : ''}>
+                                                                                                        ${escapeHtml(key)}
+                                                                                                    </option>
+                                                                                                `).join('')}
                 </select>
             </div>
             <div class="col-md-4">
@@ -933,270 +1254,277 @@ function showRelationshipModal(sourceIndex, targetIndex) {
                 <select id="relationshipTargetKey" class="form-select">
                     <option value="">- Select Target Key -</option>
                     ${targetKeyOptions.map(key => `
-                        <option value="${escapeHtml(key)}" ${existingRelationship.target_key === key ? 'selected' : ''}>
-                            ${escapeHtml(key)}
-                        </option>
-                    `).join('')}
+                                                                                                    <option value="${escapeHtml(key)}" ${existingRelationship.target_key === key ? 'selected' : ''}>
+                                                                                                        ${escapeHtml(key)}
+                                                                                                    </option>
+                                                                                                `).join('')}
                 </select>
             </div>
         </div>
     `;
 
-    const actions = [
-        {
-            id: 'saveBusinessRelationship',
-            label: 'Save Relationship',
-            className: 'btn btn-primary',
-            action: function() {
-                saveRelationship(sourceIndex, targetIndex);
-            }
-        }
-    ];
+            const actions = [{
+                id: 'saveBusinessRelationship',
+                label: 'Save Relationship',
+                className: 'btn btn-primary',
+                action: function() {
+                    saveRelationship(sourceIndex, targetIndex);
+                }
+            }];
 
-    if (existingRelationship.type) {
-        actions.unshift({
-            id: 'removeBusinessRelationship',
-            label: 'Remove',
-            className: 'btn btn-outline-danger',
-            action: function() {
-                removeRelationship(sourceIndex, targetIndex);
+            if (existingRelationship.type) {
+                actions.unshift({
+                    id: 'removeBusinessRelationship',
+                    label: 'Remove',
+                    className: 'btn btn-outline-danger',
+                    action: function() {
+                        removeRelationship(sourceIndex, targetIndex);
+                    }
+                });
             }
-        });
-    }
 
-    showModal({
-        header: {
-            enabled: true,
-            content: `
+            showModal({
+                header: {
+                    enabled: true,
+                    content: `
                 <h5 class="modal-title">Relationship</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             `,
-        },
-        body: {
-            enabled: true,
-            content: modalBody,
-        },
-        footer: {
-            enabled: true,
-            allowCancel: true,
-            actions: actions,
-        },
-    });
-}
-
-function saveRelationship(sourceIndex, targetIndex) {
-    const sourceEntity = selectedEntities[sourceIndex];
-    const targetEntity = selectedEntities[targetIndex];
-    const type = document.getElementById('relationshipType')?.value || '';
-    const sourceKey = document.getElementById('relationshipSourceKey')?.value || '';
-    const targetKey = document.getElementById('relationshipTargetKey')?.value || '';
-
-    if (!sourceEntity || !targetEntity || !type || !sourceKey || !targetKey) {
-        alert('Please select relationship type, source key, and target key.');
-        return;
-    }
-
-    relationships = relationships.filter(relationship => {
-        return !(relationship.source_entity === sourceEntity.entity
-            && relationship.target_entity === targetEntity.entity);
-    });
-
-    relationships.push({
-        source_entity: sourceEntity.entity,
-        target_entity: targetEntity.entity,
-        type: type,
-        source_key: sourceKey,
-        target_key: targetKey
-    });
-
-    bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
-    renderSelectedEntities();
-}
-
-function removeRelationship(sourceIndex, targetIndex) {
-    const sourceEntity = selectedEntities[sourceIndex];
-    const targetEntity = selectedEntities[targetIndex];
-
-    relationships = relationships.filter(relationship => {
-        return !(relationship.source_entity === sourceEntity.entity
-            && relationship.target_entity === targetEntity.entity);
-    });
-
-    bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
-    renderSelectedEntities();
-}
-
-document.addEventListener('change', function(event) {
-    if (event.target.classList.contains('business-primary-field-check')) {
-        const entityIndex = Number(event.target.dataset.entityIndex);
-        const fieldName = event.target.dataset.fieldName;
-        const selectedEntity = selectedEntities[entityIndex];
-        const sourceEntity = findEntity(selectedEntity.entity_uid);
-        const sourceField = (sourceEntity?.fields || []).find(field => getFieldName(field) === fieldName);
-
-        if (!sourceField) {
-            return;
+                },
+                body: {
+                    enabled: true,
+                    content: modalBody,
+                },
+                footer: {
+                    enabled: true,
+                    allowCancel: true,
+                    actions: actions,
+                },
+            });
         }
 
-        selectedEntity.fields = selectedEntity.fields || [];
+        function saveRelationship(sourceIndex, targetIndex) {
+            const sourceEntity = selectedEntities[sourceIndex];
+            const targetEntity = selectedEntities[targetIndex];
+            const type = document.getElementById('relationshipType')?.value || '';
+            const sourceKey = document.getElementById('relationshipSourceKey')?.value || '';
+            const targetKey = document.getElementById('relationshipTargetKey')?.value || '';
 
-        if (event.target.checked && !fieldIsSelected(selectedEntity, fieldName)) {
-            selectedEntity.fields.push(formatPrimaryField(sourceField));
+            if (!sourceEntity || !targetEntity || !type || !sourceKey || !targetKey) {
+                alert('Please select relationship type, source key, and target key.');
+                return;
+            }
+
+            relationships = relationships.filter(relationship => {
+                return !(relationship.source_entity === sourceEntity.entity &&
+                    relationship.target_entity === targetEntity.entity);
+            });
+
+            relationships.push({
+                source_entity: sourceEntity.entity,
+                target_entity: targetEntity.entity,
+                type: type,
+                source_key: sourceKey,
+                target_key: targetKey
+            });
+
+            bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
+            renderSelectedEntities();
         }
 
-        if (!event.target.checked) {
-            selectedEntity.fields = selectedEntity.fields.filter(field => getFieldName(field) !== fieldName);
+        function removeRelationship(sourceIndex, targetIndex) {
+            const sourceEntity = selectedEntities[sourceIndex];
+            const targetEntity = selectedEntities[targetIndex];
+
+            relationships = relationships.filter(relationship => {
+                return !(relationship.source_entity === sourceEntity.entity &&
+                    relationship.target_entity === targetEntity.entity);
+            });
+
+            bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
+            renderSelectedEntities();
         }
 
-        syncFieldMappingInput();
-        openEntityUid = selectedEntity.entity_uid;
-        renderSelectedEntities();
-        return;
-    }
+        document.addEventListener('change', function(event) {
+            if (event.target.classList.contains('business-primary-field-check')) {
+                const entityIndex = Number(event.target.dataset.entityIndex);
+                const fieldName = event.target.dataset.fieldName;
+                const selectedEntity = selectedEntities[entityIndex];
+                const sourceEntity = findEntity(selectedEntity.entity_uid);
+                const sourceField = (sourceEntity?.fields || []).find(field => getFieldName(field) === fieldName);
 
-    if (event.target.classList.contains('business-meta-field-check')) {
-        const entityIndex = Number(event.target.dataset.entityIndex);
-        const metaKey = event.target.dataset.metaKey;
-        const selectedEntity = selectedEntities[entityIndex];
-        const sourceEntity = findEntity(selectedEntity.entity_uid);
-        const sourceField = (sourceEntity?.meta_fields || []).find(field => getMetaFieldKey(field) === metaKey);
+                if (!sourceField) {
+                    return;
+                }
 
-        if (!sourceField) {
-            return;
-        }
+                selectedEntity.fields = selectedEntity.fields || [];
 
-        selectedEntity.meta_fields = selectedEntity.meta_fields || [];
+                if (event.target.checked && !fieldIsSelected(selectedEntity, fieldName)) {
+                    selectedEntity.fields.push(formatPrimaryField(sourceField));
+                }
 
-        if (event.target.checked && !metaFieldIsSelected(selectedEntity, metaKey)) {
-            selectedEntity.meta_fields.push(formatMetaField(sourceField));
-        }
+                if (!event.target.checked) {
+                    selectedEntity.fields = selectedEntity.fields.filter(field => getFieldName(field) !==
+                        fieldName);
+                }
 
-        if (!event.target.checked) {
-            selectedEntity.meta_fields = selectedEntity.meta_fields.filter(field => getMetaFieldKey(field) !== metaKey);
-        }
+                syncFieldMappingInput();
+                openEntityUid = selectedEntity.entity_uid;
+                renderSelectedEntities();
+                return;
+            }
 
-        syncFieldMappingInput();
-        openEntityUid = selectedEntity.entity_uid;
-        renderSelectedEntities();
-    }
-});
+            if (event.target.classList.contains('business-meta-field-check')) {
+                const entityIndex = Number(event.target.dataset.entityIndex);
+                const metaKey = event.target.dataset.metaKey;
+                const selectedEntity = selectedEntities[entityIndex];
+                const sourceEntity = findEntity(selectedEntity.entity_uid);
+                const sourceField = (sourceEntity?.meta_fields || []).find(field => getMetaFieldKey(field) ===
+                    metaKey);
 
-document.addEventListener('click', function(event) {
-    const removeButton = event.target.closest('.remove-business-entity-item');
-    if (!removeButton) {
-        return;
-    }
+                if (!sourceField) {
+                    return;
+                }
 
-    const entityIndex = Number(removeButton.dataset.entityIndex);
-    const removedEntityUid = selectedEntities[entityIndex]?.entity_uid;
-    const removedEntityName = selectedEntities[entityIndex]?.entity;
-    selectedEntities.splice(entityIndex, 1);
-    removeRelationshipsForEntity(removedEntityName);
-    selectedEntities = selectedEntities.map((selectedEntity, index) => ({
-        ...selectedEntity,
-        sort_order: index + 1
-    }));
+                selectedEntity.meta_fields = selectedEntity.meta_fields || [];
 
-    if (selectedEntities.length && !selectedEntities.some(selectedEntity => selectedEntity.is_primary)) {
-        selectedEntities[0].is_primary = true;
-    }
+                if (event.target.checked && !metaFieldIsSelected(selectedEntity, metaKey)) {
+                    selectedEntity.meta_fields.push(formatMetaField(sourceField));
+                }
 
-    if (openEntityUid === removedEntityUid) {
-        openEntityUid = selectedEntities[entityIndex]?.entity_uid
-            || selectedEntities[entityIndex - 1]?.entity_uid
-            || selectedEntities[0]?.entity_uid
-            || null;
-    }
+                if (!event.target.checked) {
+                    selectedEntity.meta_fields = selectedEntity.meta_fields.filter(field => getMetaFieldKey(
+                        field) !== metaKey);
+                }
 
-    renderSelectedEntities();
-});
-
-document.addEventListener('click', function(event) {
-    const addButton = event.target.closest('.add-business-entity-item');
-    if (addButton) {
-        showAddEntityModal();
-        return;
-    }
-
-    const relationshipButton = event.target.closest('.edit-business-relationship');
-    if (!relationshipButton) {
-        return;
-    }
-
-    showRelationshipModal(
-        Number(relationshipButton.dataset.sourceIndex),
-        Number(relationshipButton.dataset.targetIndex)
-    );
-});
-
-document.addEventListener('shown.bs.collapse', function(event) {
-    if (!event.target.id.startsWith('businessEntityItem')) {
-        return;
-    }
-
-    const entityIndex = Number(event.target.id.replace('businessEntityItem', ''));
-    openEntityUid = selectedEntities[entityIndex]?.entity_uid || openEntityUid;
-});
-
-document.addEventListener('hidden.bs.collapse', function(event) {
-    if (!event.target.id.startsWith('businessEntityItem')) {
-        return;
-    }
-
-    const accordion = document.getElementById('businessEntityItemsAccordion');
-
-    const openPanels = accordion.querySelectorAll(
-        '.accordion-collapse.show'
-    );
-
-    // If at least one is still open, do nothing
-    if (openPanels.length > 0) {
-        return;
-    }
-
-    // Find another panel to reopen
-    const allPanels = accordion.querySelectorAll(
-        '.accordion-collapse'
-    );
-
-    const panelToOpen = [...allPanels].find(
-        panel => panel.id !== event.target.id
-    );
-
-    if (panelToOpen) {
-        bootstrap.Collapse.getOrCreateInstance(panelToOpen).show();
-
-        const entityIndex = Number(
-            panelToOpen.id.replace('businessEntityItem', '')
-        );
-
-        openEntityUid = selectedEntities[entityIndex]?.entity_uid || openEntityUid;
-    }
-});
-document.getElementById('businessEntityForm').addEventListener('submit', function(event) {
-    syncFieldMappingInput();
-
-    if (!selectedEntities.length) {
-        event.preventDefault();
-        alert('Please add at least one entity.');
-        return;
-    }
-
-    if (!submitConfirmedByPreview) {
-        event.preventDefault();
-        showBusinessEntityPreviewModal({
-            title: '{{ $isCreating ? 'Review Business Entity Before Create' : 'Review Business Entity Before Update' }}',
-            confirmLabel: '{{ $isCreating ? 'Create' : 'Update' }}',
-            onConfirm: function() {
-                submitConfirmedByPreview = true;
-                bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
-                document.getElementById('businessEntityForm').requestSubmit();
+                syncFieldMappingInput();
+                openEntityUid = selectedEntity.entity_uid;
+                renderSelectedEntities();
             }
         });
-    }
-});
 
-selectedEntities = selectedEntities.map(normalizeStoredEntity);
-renderSelectedEntities();
-</script>
+        document.addEventListener('click', function(event) {
+            const removeButton = event.target.closest('.remove-business-entity-item');
+            if (!removeButton) {
+                return;
+            }
+
+            const entityIndex = Number(removeButton.dataset.entityIndex);
+            const removedEntityUid = selectedEntities[entityIndex]?.entity_uid;
+            const removedEntityName = selectedEntities[entityIndex]?.entity;
+            selectedEntities.splice(entityIndex, 1);
+            removeRelationshipsForEntity(removedEntityName);
+            selectedEntities = selectedEntities.map((selectedEntity, index) => ({
+                ...selectedEntity,
+                sort_order: index + 1
+            }));
+
+            if (selectedEntities.length && !selectedEntities.some(selectedEntity => selectedEntity.is_primary)) {
+                selectedEntities[0].is_primary = true;
+            }
+
+            if (openEntityUid === removedEntityUid) {
+                openEntityUid = selectedEntities[entityIndex]?.entity_uid ||
+                    selectedEntities[entityIndex - 1]?.entity_uid ||
+                    selectedEntities[0]?.entity_uid ||
+                    null;
+            }
+
+            renderSelectedEntities();
+        });
+
+        document.addEventListener('click', function(event) {
+            const addButton = event.target.closest('.add-business-entity-item');
+            if (addButton) {
+                showAddEntityModal();
+                return;
+            }
+
+            const associationButton = event.target.closest('.add-association-item');
+            if (associationButton) {
+                showAddAssociationModal();
+                return;
+            }
+
+            const relationshipButton = event.target.closest('.edit-business-relationship');
+            if (!relationshipButton) {
+                return;
+            }
+
+            showRelationshipModal(
+                Number(relationshipButton.dataset.sourceIndex),
+                Number(relationshipButton.dataset.targetIndex)
+            );
+        });
+
+        document.addEventListener('shown.bs.collapse', function(event) {
+            if (!event.target.id.startsWith('businessEntityItem')) {
+                return;
+            }
+
+            const entityIndex = Number(event.target.id.replace('businessEntityItem', ''));
+            openEntityUid = selectedEntities[entityIndex]?.entity_uid || openEntityUid;
+        });
+
+        document.addEventListener('hidden.bs.collapse', function(event) {
+            if (!event.target.id.startsWith('businessEntityItem')) {
+                return;
+            }
+
+            const accordion = document.getElementById('businessEntityItemsAccordion');
+
+            const openPanels = accordion.querySelectorAll(
+                '.accordion-collapse.show'
+            );
+
+            // If at least one is still open, do nothing
+            if (openPanels.length > 0) {
+                return;
+            }
+
+            // Find another panel to reopen
+            const allPanels = accordion.querySelectorAll(
+                '.accordion-collapse'
+            );
+
+            const panelToOpen = [...allPanels].find(
+                panel => panel.id !== event.target.id
+            );
+
+            if (panelToOpen) {
+                bootstrap.Collapse.getOrCreateInstance(panelToOpen).show();
+
+                const entityIndex = Number(
+                    panelToOpen.id.replace('businessEntityItem', '')
+                );
+
+                openEntityUid = selectedEntities[entityIndex]?.entity_uid || openEntityUid;
+            }
+        });
+        document.getElementById('businessEntityForm').addEventListener('submit', function(event) {
+            syncFieldMappingInput();
+
+            if (!selectedEntities.length) {
+                event.preventDefault();
+                alert('Please add at least one entity.');
+                return;
+            }
+
+            if (!submitConfirmedByPreview) {
+                event.preventDefault();
+                showBusinessEntityPreviewModal({
+                    title: '{{ $isCreating ? 'Review Business Entity Before Create' : 'Review Business Entity Before Update' }}',
+                    confirmLabel: '{{ $isCreating ? 'Create' : 'Update' }}',
+                    onConfirm: function() {
+                        submitConfirmedByPreview = true;
+                        bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
+                        document.getElementById('businessEntityForm').requestSubmit();
+                    }
+                });
+            }
+        });
+
+        selectedEntities = selectedEntities.map(normalizeStoredEntity);
+        renderSelectedEntities();
+    </script>
 @endpush

--- a/resources/views/business_entity/create-edit.blade.php
+++ b/resources/views/business_entity/create-edit.blade.php
@@ -102,7 +102,7 @@
                 </div>
             </div>
 
-            <div class="alert alert-info mb-3">
+            <div class="alert alert-info mb-2">
                 Select entities, choose primary and meta fields, then save. Only selected fields are stored in <code>field_mapping</code>.
             </div>
         </div>
@@ -143,6 +143,99 @@
 <style>
     .business-entity-sticky-top {
         z-index: 900;
+    }
+
+    .business-entity-tree,
+    .business-entity-tree ul,
+    .business-entity-tree li {
+        list-style: none;
+        margin: 0;
+        padding-left: 0;
+    }
+
+    .business-entity-tree {
+        min-width: max-content;
+    }
+
+    .business-entity-tree .tree-item {
+        position: relative;
+        margin-bottom: 4px;
+    }
+
+    .business-entity-tree .tree-item-content {
+        padding: 4px 8px;
+        border-radius: 4px;
+    }
+
+    .business-entity-tree .tree-item-children {
+        margin-left: 25px;
+        margin-top: 4px;
+        position: relative;
+    }
+
+    .business-entity-tree .tree-item-children::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: -4px;
+        bottom: 20px;
+        width: 1px;
+        border-left: 1px solid #adb5bd;
+    }
+
+    .business-entity-tree .tree-item-children .tree-item::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 18px;
+        width: 20px;
+        border-top: 1px solid #adb5bd;
+    }
+
+    .business-entity-tree .tree-item-children .tree-item-content {
+        padding-left: 25px;
+    }
+
+    .business-entity-tree .tree-item-value {
+        color: #6c757d;
+        margin-left: 6px;
+    }
+
+    .business-entity-tree-header {
+        padding: 4px 8px;
+    }
+
+    .business-entity-sequence {
+        margin-left: 25px;
+        position: relative;
+    }
+
+    .business-entity-sequence::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 18px;
+        bottom: 20px;
+        width: 1px;
+        border-left: 1px solid #adb5bd;
+    }
+
+    .business-entity-sequence > .tree-item::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 18px;
+        width: 20px;
+        border-top: 1px solid #adb5bd;
+    }
+
+    .business-entity-sequence > .tree-item > .tree-item-content {
+        padding-left: 25px;
+    }
+
+    .business-relationship-row {
+        justify-content: flex-start;
+        margin-left: 0;
     }
 </style>
 @endpush
@@ -243,6 +336,7 @@ let relationships = Array.isArray(existingMapping.relationships)
     ? existingMapping.relationships.map(normalizeRelationship)
     : [];
 let openEntityUid = selectedEntities[selectedEntities.length - 1]?.entity_uid || null;
+let submitConfirmedByPreview = false;
 
 function buildMapping() {
     return {
@@ -309,6 +403,169 @@ function escapeHtml(value) {
         .replace(/'/g, '&#039;');
 }
 
+function getMappingFieldName(field) {
+    return field.field || field.name || field.meta_key || '';
+}
+
+function getMappingMetaFieldName(field) {
+    return field.meta_key || field.field || field.name || '';
+}
+
+function getDisplayMetaFieldName(field) {
+    const metaFieldName = getMappingMetaFieldName(field);
+
+    return metaFieldName.startsWith('m_') ? metaFieldName : `m_${metaFieldName}`;
+}
+
+function renderTreeNode(label, value = '', children = '', icon = 'fa-circle') {
+    return `
+        <li class="tree-item">
+            <div class="tree-item-content">
+                <i class="fas fa-fw ${icon} text-muted me-1"></i>
+                <span class="tree-item-key">${escapeHtml(label)}</span>
+                ${value ? `<span class="tree-item-value">- ${escapeHtml(value)}</span>` : ''}
+            </div>
+            ${children ? `<ul class="tree-item-children">${children}</ul>` : ''}
+        </li>
+    `;
+}
+
+function renderFieldTree(fields, emptyLabel) {
+    if (!fields.length) {
+        return renderTreeNode(emptyLabel, '', '', 'fa-minus');
+    }
+
+    return fields.map(field => renderTreeNode(
+        getMappingFieldName(field),
+        [field.label, field.type].filter(Boolean).join(' | '),
+        '',
+        'fa-table-columns'
+    )).join('');
+}
+
+function renderMetaFieldTree(fields) {
+    return fields.map(field => renderTreeNode(
+        getDisplayMetaFieldName(field),
+        [field.label, field.type].filter(Boolean).join(' | '),
+        '',
+        'fa-tags'
+    )).join('');
+}
+
+function findRelationshipsBetween(sourceEntity, targetEntity, mappingRelationships) {
+    return mappingRelationships.filter(relationship => {
+        return (
+            relationship.source_entity === sourceEntity.entity
+            && relationship.target_entity === targetEntity.entity
+        ) || (
+            relationship.source_entity === targetEntity.entity
+            && relationship.target_entity === sourceEntity.entity
+        );
+    });
+}
+
+function renderRelationshipConnector(sourceEntity, targetEntity, mappingRelationships) {
+    const matchingRelationships = findRelationshipsBetween(sourceEntity, targetEntity, mappingRelationships);
+
+    if (!matchingRelationships.length) {
+        return renderTreeNode(
+            `${sourceEntity.entity || 'source'} -> ${targetEntity.entity || 'target'}`,
+            'No relationship configured',
+            '',
+            'fa-link'
+        );
+    }
+
+    return matchingRelationships.map(relationship => {
+        const relationLabel = `${relationship.source_entity || 'source'} -> ${relationship.target_entity || 'target'}`;
+        const relationValue = [
+            relationship.type,
+            relationship.source_key && relationship.target_key
+                ? `${relationship.source_key} -> ${relationship.target_key}`
+                : ''
+        ].filter(Boolean).join(' | ');
+
+        return renderTreeNode(relationLabel, relationValue, '', 'fa-link');
+    }).join('');
+}
+
+function renderBusinessEntityTree(mapping) {
+    const mappingRelationships = mapping.relationships || [];
+    const entityNodes = (mapping.entities || []).map((entity, index) => {
+        const entityFields = [
+            renderFieldTree(entity.fields || [], 'No fields selected'),
+            renderMetaFieldTree(entity.meta_fields || [])
+        ].join('');
+        const entityNode = renderTreeNode(
+            entity.entity || 'Unnamed entity',
+            entity.is_primary ? 'Primary' : '',
+            entityFields || renderTreeNode('No fields selected', '', '', 'fa-minus'),
+            entity.is_primary ? 'fa-star' : 'fa-table'
+        );
+        const nextEntity = (mapping.entities || [])[index + 1];
+
+        if (!nextEntity) {
+            return entityNode;
+        }
+
+        return entityNode + renderTreeNode(
+            'Relationship',
+            '',
+            renderRelationshipConnector(entity, nextEntity, mappingRelationships),
+            'fa-diagram-project'
+        );
+    }).join('');
+
+    return `
+        <div class="overflow-auto bg-light border rounded p-2" style="max-height: 60vh;">
+            <div class="business-entity-tree-header">
+                <i class="fas fa-fw fa-sitemap text-muted me-1"></i>
+                <span class="tree-item-key">Selected Entities / Tables</span>
+                <span class="tree-item-value">- ${(mapping.entities || []).length} selected</span>
+            </div>
+            <ul class="business-entity-tree business-entity-sequence">
+                ${entityNodes || renderTreeNode('No entities selected', '', '', 'fa-minus')}
+            </ul>
+        </div>
+    `;
+}
+
+function showBusinessEntityPreviewModal(options = {}) {
+    syncFieldMappingInput();
+    const mapping = buildMapping();
+    const modalBody = document.createElement('div');
+    modalBody.innerHTML = renderBusinessEntityTree(mapping);
+    const actions = [];
+
+    if (typeof options.onConfirm === 'function') {
+        actions.push({
+            id: 'confirmBusinessEntitySave',
+            label: options.confirmLabel || 'Continue',
+            className: 'btn btn-primary',
+            action: options.onConfirm
+        });
+    }
+
+    showModal({
+        header: {
+            enabled: true,
+            content: `
+                <h5 class="modal-title">${escapeHtml(options.title || 'Business Entity Mapping')}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            `,
+        },
+        body: {
+            enabled: true,
+            content: modalBody,
+        },
+        footer: {
+            enabled: true,
+            allowCancel: true,
+            actions: actions,
+        },
+    });
+}
+
 function getEntityKeyOptions(entityUid) {
     const entity = findEntity(entityUid);
     const primaryKeys = (entity?.fields || []).map(getFieldName).filter(Boolean);
@@ -344,8 +601,7 @@ function renderRelationshipButton(sourceEntity, targetEntity, sourceIndex) {
         : 'Relationship';
 
     return `
-        <div class="d-flex align-items-center gap-2 my-2 ps-2">
-            <div class="border-top flex-grow-1"></div>
+        <div class="d-flex align-items-center gap-2 my-2 business-relationship-row">
             <button type="button"
                 class="btn btn-sm ${relationship ? 'btn-outline-success' : 'btn-outline-secondary'} edit-business-relationship"
                 data-source-index="${sourceIndex}"
@@ -353,7 +609,6 @@ function renderRelationshipButton(sourceEntity, targetEntity, sourceIndex) {
                 <i class="fa-solid fa-fw fa-link"></i>
                 <span class="ms-1">${label}</span>
             </button>
-            <div class="border-top flex-grow-1"></div>
         </div>
     `;
 }
@@ -883,12 +1138,61 @@ document.addEventListener('shown.bs.collapse', function(event) {
     openEntityUid = selectedEntities[entityIndex]?.entity_uid || openEntityUid;
 });
 
+document.addEventListener('hidden.bs.collapse', function(event) {
+    if (!event.target.id.startsWith('businessEntityItem')) {
+        return;
+    }
+
+    const accordion = document.getElementById('businessEntityItemsAccordion');
+
+    const openPanels = accordion.querySelectorAll(
+        '.accordion-collapse.show'
+    );
+
+    // If at least one is still open, do nothing
+    if (openPanels.length > 0) {
+        return;
+    }
+
+    // Find another panel to reopen
+    const allPanels = accordion.querySelectorAll(
+        '.accordion-collapse'
+    );
+
+    const panelToOpen = [...allPanels].find(
+        panel => panel.id !== event.target.id
+    );
+
+    if (panelToOpen) {
+        bootstrap.Collapse.getOrCreateInstance(panelToOpen).show();
+
+        const entityIndex = Number(
+            panelToOpen.id.replace('businessEntityItem', '')
+        );
+
+        openEntityUid = selectedEntities[entityIndex]?.entity_uid || openEntityUid;
+    }
+});
 document.getElementById('businessEntityForm').addEventListener('submit', function(event) {
     syncFieldMappingInput();
 
     if (!selectedEntities.length) {
         event.preventDefault();
         alert('Please add at least one entity.');
+        return;
+    }
+
+    if (!submitConfirmedByPreview) {
+        event.preventDefault();
+        showBusinessEntityPreviewModal({
+            title: '{{ $isCreating ? 'Review Business Entity Before Create' : 'Review Business Entity Before Update' }}',
+            confirmLabel: '{{ $isCreating ? 'Create' : 'Update' }}',
+            onConfirm: function() {
+                submitConfirmedByPreview = true;
+                bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
+                document.getElementById('businessEntityForm').requestSubmit();
+            }
+        });
     }
 });
 

--- a/resources/views/business_entity/create-edit.blade.php
+++ b/resources/views/business_entity/create-edit.blade.php
@@ -1,0 +1,898 @@
+@extends('userinterface::layouts.app')
+
+@section('content')
+@php
+    $isCreating = $isCreating ?? true;
+
+    $entityOptions = $entities->map(function ($entity) {
+        $fields = is_string($entity->fields)
+            ? json_decode($entity->fields, true)
+            : ($entity->fields ?? []);
+
+        $metaFields = is_string($entity->meta_fields)
+            ? json_decode($entity->meta_fields, true)
+            : ($entity->meta_fields ?? []);
+
+        return [
+            'uid' => $entity->uid,
+            'entity_name' => $entity->entity_name,
+            'slug' => $entity->slug,
+            'fields' => array_values($fields ?: []),
+            'meta_fields' => array_values($metaFields ?: []),
+        ];
+    })->values();
+
+    $fieldMapping = $businessEntity?->field_mapping ?? [];
+    if (is_string($fieldMapping)) {
+        $fieldMapping = json_decode($fieldMapping, true) ?: [];
+    }
+@endphp
+
+<form id="businessEntityForm" method="POST" action="{{ $isCreating ? route('business-entities.store') : route('business-entities.update', $businessEntity->uid) }}">
+    @csrf
+    @if(!$isCreating)
+        @method('PUT')
+    @endif
+
+    <input type="hidden" id="field_mapping" name="field_mapping" value="{{ old('field_mapping') }}">
+
+    <div class="mb-3">
+            <div class="sticky-top business-entity-sticky-top bg-body pb-2">
+            <div class="mb-3">
+                <h5 class="mb-1 fs-6">
+                    {{ $isCreating ? 'Create New Business Entity' : 'Edit Business Entity' }}
+                </h5>
+                <p class="mb-0 text-muted">
+                    UID will be auto-generated
+                </p>
+            </div>
+
+            <div class="mb-3">
+                <div class="row px-2">
+                    <div class="col-md-4">
+                        <label for="business_entity_name" class="form-label">
+                            Business Entity Name <span class="text-danger">*</span>
+                        </label>
+                        <input type="text"
+                            class="form-control @error('business_entity_name') is-invalid @enderror"
+                            id="business_entity_name"
+                            name="business_entity_name"
+                            value="{{ old('business_entity_name', $businessEntity->business_entity_name ?? '') }}"
+                            required>
+                        @error('business_entity_name')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="col-md-4">
+                        <label for="ref_module" class="form-label">
+                            Module <span class="text-danger">*</span>
+                            <small>If no module is available, please create one.</small>
+                        </label>
+
+                        <select
+                            class="form-select @error('ref_module') is-invalid @enderror"
+                            id="ref_module"
+                            name="ref_module"
+                            required>
+                            <option value="">- Select Module -</option>
+
+                            @foreach($modules as $module)
+                                <option value="{{ $module->id }}"
+                                    {{ old('ref_module', $businessEntity->ref_module ?? null) == $module->id ? 'selected' : '' }}>
+                                    {{ ucfirst(str_replace('-', ' ', $module->name)) }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('ref_module')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="col-md-4">
+                        <label for="desc" class="form-label">Description</label>
+                        <textarea class="form-control @error('desc') is-invalid @enderror"
+                            id="desc"
+                            name="desc"
+                            rows="3">{{ old('desc', $businessEntity->desc ?? '') }}</textarea>
+                        @error('desc')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                </div>
+            </div>
+
+            <div class="alert alert-info mb-3">
+                Select entities, choose primary and meta fields, then save. Only selected fields are stored in <code>field_mapping</code>.
+            </div>
+        </div>
+
+        <div class="accordion" id="businessEntityAccordion">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="selectedEntitiesHeader">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#selectedEntities">
+                        Selected Entities / Tables
+                    </button>
+                </h2>
+                <div id="selectedEntities" class="accordion-collapse collapse show" data-bs-parent="#businessEntityAccordion">
+                    <div class="accordion-body">
+                        <div class="mb-3">
+                            <button type="button" id="primaryAddBusinessEntityItem" class="btn btn-sm btn-outline-primary add-business-entity-item">
+                                <i class="fa-regular fa-fw fa-plus"></i>
+                                <span class="ms-1">Add Entity</span>
+                            </button>
+                        </div>
+
+                        <div id="selectedEntityPanels"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="d-flex align-items-center justify-content-end mb-3 gap-2">
+        <a href="{{ route('business-entities.index') }}" class="btn btn-sm btn-outline-dark">Cancel</a>
+        <button type="submit" class="btn btn-sm btn-outline-primary">
+            {{ $isCreating ? 'Create' : 'Update' }}
+        </button>
+    </div>
+</form>
+@endsection
+
+@push('styles')
+<style>
+    .business-entity-sticky-top {
+        z-index: 900;
+    }
+</style>
+@endpush
+
+@push('scripts')
+<script>
+let availableEntities = @json($entityOptions);
+const existingMapping = @json(old('field_mapping') ? json_decode(old('field_mapping'), true) : $fieldMapping);
+const relationshipTypes = [
+    'belongs_to',
+    'has_one',
+    'has_many',
+    'belongs_to_many',
+    'many_to_many',
+    'has_many_through',
+    'morph_one',
+    'morph_many',
+    'morph_to',
+    'morph_to_many',
+    'morphed_by_many',
+    'one_to_one',
+    'one_to_many'
+];
+
+function findEntity(entityUid) {
+    return availableEntities.find(entity => String(entity.uid) === String(entityUid));
+}
+
+function getFieldName(field) {
+    return field.name || field.field || field.meta_key || '';
+}
+
+function getFieldLabel(field) {
+    return field.label || getFieldName(field);
+}
+
+function getMetaFieldKey(field) {
+    return field.meta_key || field.field || field.name || '';
+}
+
+function getStoredFields(entityMapping) {
+    return entityMapping.fields || entityMapping.selected_fields || [];
+}
+
+function getStoredMetaFields(entityMapping) {
+    return entityMapping.meta_fields || entityMapping.selected_meta_fields || [];
+}
+
+function normalizeRelationship(relationship) {
+    return {
+        source_entity: relationship.source_entity || relationship.from_entity || '',
+        target_entity: relationship.target_entity || relationship.to_entity || '',
+        type: relationship.type || relationship.relation_type || '',
+        source_key: relationship.source_key || relationship.from_field || '',
+        target_key: relationship.target_key || relationship.to_field || ''
+    };
+}
+
+function normalizeStoredEntity(entityMapping, index) {
+    const sourceEntity = availableEntities.find(entity => {
+        return String(entity.uid) === String(entityMapping.entity_uid)
+            || String(entity.entity_name) === String(entityMapping.entity);
+    });
+
+    const entityName = entityMapping.entity || sourceEntity?.entity_name || '';
+
+    return {
+        entity_uid: entityMapping.entity_uid || sourceEntity?.uid || '',
+        entity: entityName,
+        slug: entityMapping.slug || sourceEntity?.slug || null,
+        is_primary: Boolean(entityMapping.is_primary),
+        sort_order: entityMapping.sort_order || index + 1,
+        fields: getStoredFields(entityMapping).map(field => ({
+            field: getFieldName(field),
+            label: getFieldLabel(field),
+            type: field.type || '',
+            input_type: field.input_type || null,
+            required: Boolean(field.required),
+            nullable: Boolean(field.nullable),
+            default: field.default ?? null
+        })),
+        meta_fields: getStoredMetaFields(entityMapping).map(field => ({
+            meta_key: getMetaFieldKey(field),
+            label: getFieldLabel(field),
+            type: field.type || '',
+            input_type: field.input_type || null,
+            required: Boolean(field.required),
+            nullable: Boolean(field.nullable),
+            display: field.display ?? true
+        }))
+    };
+}
+
+let selectedEntities = Array.isArray(existingMapping.entities)
+    ? existingMapping.entities.map(normalizeStoredEntity)
+    : [];
+let relationships = Array.isArray(existingMapping.relationships)
+    ? existingMapping.relationships.map(normalizeRelationship)
+    : [];
+let openEntityUid = selectedEntities[selectedEntities.length - 1]?.entity_uid || null;
+
+function buildMapping() {
+    return {
+        primary_entity: selectedEntities.find(entity => entity.is_primary)?.entity || null,
+        entities: selectedEntities.map((entity, index) => ({
+            entity_uid: entity.entity_uid,
+            entity: entity.entity,
+            slug: entity.slug,
+            is_primary: entity.is_primary,
+            sort_order: index + 1,
+            fields: entity.fields,
+            meta_fields: entity.meta_fields,
+            relationships: relationships.filter(relationship => {
+                return relationship.source_entity === entity.entity
+                    || relationship.target_entity === entity.entity;
+            })
+        })),
+        relationships: relationships
+    };
+}
+
+function syncFieldMappingInput() {
+    document.getElementById('field_mapping').value = JSON.stringify(buildMapping());
+}
+
+function fieldIsSelected(selectedEntity, fieldName) {
+    return (selectedEntity.fields || []).some(field => getFieldName(field) === fieldName);
+}
+
+function metaFieldIsSelected(selectedEntity, metaKey) {
+    return (selectedEntity.meta_fields || []).some(field => getMetaFieldKey(field) === metaKey);
+}
+
+function formatPrimaryField(field) {
+    return {
+        field: getFieldName(field),
+        label: getFieldLabel(field),
+        type: field.type || '',
+        input_type: field.input_type || null,
+        required: Boolean(field.required),
+        nullable: Boolean(field.nullable),
+        default: field.default ?? null
+    };
+}
+
+function formatMetaField(field) {
+    return {
+        meta_key: getMetaFieldKey(field),
+        label: getFieldLabel(field),
+        type: field.type || '',
+        input_type: field.input_type || null,
+        required: Boolean(field.required),
+        nullable: Boolean(field.nullable),
+        display: field.display ?? true
+    };
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function getEntityKeyOptions(entityUid) {
+    const entity = findEntity(entityUid);
+    const primaryKeys = (entity?.fields || []).map(getFieldName).filter(Boolean);
+    const metaKeys = (entity?.meta_fields || []).map(getMetaFieldKey).filter(Boolean);
+
+    return [...new Set([...primaryKeys, ...metaKeys])];
+}
+
+function getUnselectedEntities() {
+    const selectedUids = selectedEntities.map(entity => String(entity.entity_uid));
+
+    return availableEntities.filter(entity => !selectedUids.includes(String(entity.uid)));
+}
+
+function getRelationshipBetween(sourceEntity, targetEntity) {
+    return relationships.find(relationship => {
+        return relationship.source_entity === sourceEntity.entity
+            && relationship.target_entity === targetEntity.entity;
+    });
+}
+
+function removeRelationshipsForEntity(entityName) {
+    relationships = relationships.filter(relationship => {
+        return relationship.source_entity !== entityName
+            && relationship.target_entity !== entityName;
+    });
+}
+
+function renderRelationshipButton(sourceEntity, targetEntity, sourceIndex) {
+    const relationship = getRelationshipBetween(sourceEntity, targetEntity);
+    const label = relationship
+        ? `${escapeHtml(relationship.type)}: ${escapeHtml(relationship.source_key || 'source')} -> ${escapeHtml(relationship.target_key || 'target')}`
+        : 'Relationship';
+
+    return `
+        <div class="d-flex align-items-center gap-2 my-2 ps-2">
+            <div class="border-top flex-grow-1"></div>
+            <button type="button"
+                class="btn btn-sm ${relationship ? 'btn-outline-success' : 'btn-outline-secondary'} edit-business-relationship"
+                data-source-index="${sourceIndex}"
+                data-target-index="${sourceIndex + 1}">
+                <i class="fa-solid fa-fw fa-link"></i>
+                <span class="ms-1">${label}</span>
+            </button>
+            <div class="border-top flex-grow-1"></div>
+        </div>
+    `;
+}
+
+function renderFieldRows(selectedEntity, sourceEntity, entityIndex) {
+    const fields = sourceEntity?.fields || [];
+
+    if (!fields.length) {
+        return '<tr><td colspan="7" class="text-center text-muted">No primary fields available.</td></tr>';
+    }
+
+    return fields.map(field => {
+        const fieldName = getFieldName(field);
+
+        return `
+            <tr>
+                <td>
+                    <input type="checkbox" class="form-check-input business-primary-field-check"
+                        data-entity-index="${entityIndex}"
+                        data-field-name="${escapeHtml(fieldName)}"
+                        ${fieldIsSelected(selectedEntity, fieldName) ? 'checked' : ''}>
+                </td>
+                <td>${escapeHtml(fieldName)}</td>
+                <td>${escapeHtml(field.type || '')}</td>
+                <td>${escapeHtml(getFieldLabel(field))}</td>
+                <td>${field.required ? 'Yes' : 'No'}</td>
+                <td>${field.nullable ? 'Yes' : 'No'}</td>
+                <td>${escapeHtml(field.input_type || '')}</td>
+            </tr>
+        `;
+    }).join('');
+}
+
+function renderMetaFieldRows(selectedEntity, sourceEntity, entityIndex) {
+    const metaFields = sourceEntity?.meta_fields || [];
+
+    if (!metaFields.length) {
+        return '<tr><td colspan="7" class="text-center text-muted">No meta fields available.</td></tr>';
+    }
+
+    return metaFields.map(field => {
+        const metaKey = getMetaFieldKey(field);
+
+        return `
+            <tr>
+                <td>
+                    <input type="checkbox" class="form-check-input business-meta-field-check"
+                        data-entity-index="${entityIndex}"
+                        data-meta-key="${escapeHtml(metaKey)}"
+                        ${metaFieldIsSelected(selectedEntity, metaKey) ? 'checked' : ''}>
+                </td>
+                <td>${escapeHtml(metaKey)}</td>
+                <td>${escapeHtml(field.type || '')}</td>
+                <td>${escapeHtml(getFieldLabel(field))}</td>
+                <td>${field.required ? 'Yes' : 'No'}</td>
+                <td>${field.nullable ? 'Yes' : 'No'}</td>
+                <td>${escapeHtml(field.input_type || '')}</td>
+            </tr>
+        `;
+    }).join('');
+}
+
+function renderSelectedEntities() {
+    const wrapper = document.getElementById('selectedEntityPanels');
+    const primaryAddButton = document.getElementById('primaryAddBusinessEntityItem');
+    const hasUnselectedEntities = getUnselectedEntities().length > 0;
+
+    if (primaryAddButton) {
+        primaryAddButton.disabled = !hasUnselectedEntities;
+    }
+
+    wrapper.innerHTML = '';
+
+    if (!selectedEntities.length) {
+        wrapper.innerHTML = '<div class="text-center text-muted border rounded p-3">No entities added.</div>';
+        syncFieldMappingInput();
+        return;
+    }
+
+    wrapper.insertAdjacentHTML('beforeend', '<div class="accordion" id="businessEntityItemsAccordion"></div>');
+    const accordion = document.getElementById('businessEntityItemsAccordion');
+
+    selectedEntities.forEach((selectedEntity, entityIndex) => {
+        const sourceEntity = findEntity(selectedEntity.entity_uid);
+        const selectedCount = (selectedEntity.fields || []).length + (selectedEntity.meta_fields || []).length;
+        const collapseId = `businessEntityItem${entityIndex}`;
+        const headerId = `businessEntityItemHeader${entityIndex}`;
+        const isOpen = openEntityUid
+            ? selectedEntity.entity_uid === openEntityUid
+            : entityIndex === selectedEntities.length - 1;
+
+        accordion.insertAdjacentHTML('beforeend', `
+            <div class="accordion-item mb-2 border rounded">
+                <h2 class="accordion-header" id="${headerId}">
+                    <div class="d-flex align-items-center bg-light">
+                        <button
+                            class="accordion-button ${isOpen ? '' : 'collapsed'} bg-light py-2"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#${collapseId}"
+                            aria-expanded="${isOpen ? 'true' : 'false'}"
+                            aria-controls="${collapseId}">
+                            <strong>${escapeHtml(selectedEntity.entity)}</strong>
+                            <span class="text-muted ms-2">${selectedCount} selected fields</span>
+                            ${selectedEntity.is_primary ? '<span class="badge bg-primary ms-2">Primary</span>' : ''}
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-danger me-3 remove-business-entity-item" data-entity-index="${entityIndex}">
+                            <i class="fas fa-fw fa-trash"></i>
+                        </button>
+                    </div>
+                </h2>
+
+                <div id="${collapseId}" class="accordion-collapse collapse ${isOpen ? 'show' : ''}" aria-labelledby="${headerId}">
+                    <div class="accordion-body p-3">
+                        <h6 class="text-primary">Primary Fields</h6>
+                        <div class="table-responsive mb-3">
+                            <table class="table table-sm table-bordered mb-0">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 70px;">#</th>
+                                        <th>Field</th>
+                                        <th>Type</th>
+                                        <th>Label</th>
+                                        <th>Required</th>
+                                        <th>Nullable</th>
+                                        <th>Input</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    ${renderFieldRows(selectedEntity, sourceEntity, entityIndex)}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <h6 class="text-success">Meta Fields</h6>
+                        <div class="table-responsive">
+                            <table class="table table-sm table-bordered mb-0">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 70px;">#</th>
+                                        <th>Meta Key</th>
+                                        <th>Type</th>
+                                        <th>Label</th>
+                                        <th>Required</th>
+                                        <th>Nullable</th>
+                                        <th>Input</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    ${renderMetaFieldRows(selectedEntity, sourceEntity, entityIndex)}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `);
+
+        if (selectedEntities[entityIndex + 1]) {
+            accordion.insertAdjacentHTML('beforeend', renderRelationshipButton(
+                selectedEntity,
+                selectedEntities[entityIndex + 1],
+                entityIndex
+            ));
+        }
+    });
+
+    syncFieldMappingInput();
+}
+
+function showAddEntityModal() {
+    const modalBody = document.createElement('div');
+    modalBody.innerHTML = `
+        <div class="row g-3">
+            <div class="col-12">
+                <label for="modalEntitySelector" class="form-label">Entity / Table</label>
+                <select id="modalEntitySelector" class="form-select">
+                    <option value="">- Select Entity -</option>
+                    ${availableEntities.map(entity => {
+                        const isSelected = selectedEntities.some(selectedEntity => {
+                            return String(selectedEntity.entity_uid) === String(entity.uid);
+                        });
+
+                        return `
+                            <option value="${escapeHtml(entity.uid)}" ${isSelected ? 'disabled' : ''}>
+                                ${escapeHtml(entity.entity_name)}${isSelected ? ' (already selected)' : ''}
+                            </option>
+                        `;
+                    }).join('')}
+                </select>
+            </div>
+            <div class="col-12">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="modalEntityPrimary" ${selectedEntities.length === 0 ? 'checked disabled' : ''}>
+                    <label class="form-check-label" for="modalEntityPrimary">Primary</label>
+                </div>
+            </div>
+        </div>
+    `;
+
+    showModal({
+        header: {
+            enabled: true,
+            content: `
+                <h5 class="modal-title">Add Entity</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            `,
+        },
+        body: {
+            enabled: true,
+            content: modalBody,
+        },
+        footer: {
+            enabled: true,
+            allowCancel: true,
+            actions: [
+                {
+                    id: 'confirmBusinessEntityItem',
+                    label: 'Add Entity',
+                    className: 'btn btn-primary',
+                    action: function() {
+                        addSelectedEntityFromModal();
+                    }
+                }
+            ],
+        },
+    });
+}
+
+function addSelectedEntityFromModal() {
+    const selector = document.getElementById('modalEntitySelector');
+    const primaryInput = document.getElementById('modalEntityPrimary');
+    const entity = findEntity(selector?.value);
+
+    if (!entity) {
+        return;
+    }
+
+    if (selectedEntities.some(selectedEntity => String(selectedEntity.entity_uid) === String(entity.uid))) {
+        return;
+    }
+
+    const isPrimary = primaryInput?.checked || selectedEntities.length === 0;
+
+    if (isPrimary) {
+        selectedEntities = selectedEntities.map(selectedEntity => ({
+            ...selectedEntity,
+            is_primary: false
+        }));
+    }
+
+    const newSelectedEntity = {
+        entity_uid: entity.uid,
+        entity: entity.entity_name,
+        slug: entity.slug,
+        is_primary: isPrimary,
+        sort_order: selectedEntities.length + 1,
+        fields: [],
+        meta_fields: []
+    };
+
+    selectedEntities.push(newSelectedEntity);
+
+    selectedEntities = selectedEntities.map((selectedEntity, index) => ({
+        ...selectedEntity,
+        sort_order: index + 1
+    }));
+
+    openEntityUid = entity.uid;
+
+    bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
+    renderSelectedEntities();
+}
+
+function showRelationshipModal(sourceIndex, targetIndex) {
+    const sourceEntity = selectedEntities[sourceIndex];
+    const targetEntity = selectedEntities[targetIndex];
+
+    if (!sourceEntity || !targetEntity) {
+        return;
+    }
+
+    const existingRelationship = getRelationshipBetween(sourceEntity, targetEntity) || {};
+    const sourceKeyOptions = getEntityKeyOptions(sourceEntity.entity_uid);
+    const targetKeyOptions = getEntityKeyOptions(targetEntity.entity_uid);
+    const modalBody = document.createElement('div');
+
+    modalBody.innerHTML = `
+        <div class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Source Entity</label>
+                <input type="text" class="form-control" value="${escapeHtml(sourceEntity.entity)}" disabled>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Target Entity</label>
+                <input type="text" class="form-control" value="${escapeHtml(targetEntity.entity)}" disabled>
+            </div>
+            <div class="col-md-4">
+                <label for="relationshipType" class="form-label">Type</label>
+                <select id="relationshipType" class="form-select">
+                    <option value="">- Select Type -</option>
+                    ${relationshipTypes.map(type => `
+                        <option value="${escapeHtml(type)}" ${existingRelationship.type === type ? 'selected' : ''}>
+                            ${escapeHtml(type.replace(/_/g, ' '))}
+                        </option>
+                    `).join('')}
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label for="relationshipSourceKey" class="form-label">Source Key</label>
+                <select id="relationshipSourceKey" class="form-select">
+                    <option value="">- Select Source Key -</option>
+                    ${sourceKeyOptions.map(key => `
+                        <option value="${escapeHtml(key)}" ${existingRelationship.source_key === key ? 'selected' : ''}>
+                            ${escapeHtml(key)}
+                        </option>
+                    `).join('')}
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label for="relationshipTargetKey" class="form-label">Target Key</label>
+                <select id="relationshipTargetKey" class="form-select">
+                    <option value="">- Select Target Key -</option>
+                    ${targetKeyOptions.map(key => `
+                        <option value="${escapeHtml(key)}" ${existingRelationship.target_key === key ? 'selected' : ''}>
+                            ${escapeHtml(key)}
+                        </option>
+                    `).join('')}
+                </select>
+            </div>
+        </div>
+    `;
+
+    const actions = [
+        {
+            id: 'saveBusinessRelationship',
+            label: 'Save Relationship',
+            className: 'btn btn-primary',
+            action: function() {
+                saveRelationship(sourceIndex, targetIndex);
+            }
+        }
+    ];
+
+    if (existingRelationship.type) {
+        actions.unshift({
+            id: 'removeBusinessRelationship',
+            label: 'Remove',
+            className: 'btn btn-outline-danger',
+            action: function() {
+                removeRelationship(sourceIndex, targetIndex);
+            }
+        });
+    }
+
+    showModal({
+        header: {
+            enabled: true,
+            content: `
+                <h5 class="modal-title">Relationship</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            `,
+        },
+        body: {
+            enabled: true,
+            content: modalBody,
+        },
+        footer: {
+            enabled: true,
+            allowCancel: true,
+            actions: actions,
+        },
+    });
+}
+
+function saveRelationship(sourceIndex, targetIndex) {
+    const sourceEntity = selectedEntities[sourceIndex];
+    const targetEntity = selectedEntities[targetIndex];
+    const type = document.getElementById('relationshipType')?.value || '';
+    const sourceKey = document.getElementById('relationshipSourceKey')?.value || '';
+    const targetKey = document.getElementById('relationshipTargetKey')?.value || '';
+
+    if (!sourceEntity || !targetEntity || !type || !sourceKey || !targetKey) {
+        alert('Please select relationship type, source key, and target key.');
+        return;
+    }
+
+    relationships = relationships.filter(relationship => {
+        return !(relationship.source_entity === sourceEntity.entity
+            && relationship.target_entity === targetEntity.entity);
+    });
+
+    relationships.push({
+        source_entity: sourceEntity.entity,
+        target_entity: targetEntity.entity,
+        type: type,
+        source_key: sourceKey,
+        target_key: targetKey
+    });
+
+    bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
+    renderSelectedEntities();
+}
+
+function removeRelationship(sourceIndex, targetIndex) {
+    const sourceEntity = selectedEntities[sourceIndex];
+    const targetEntity = selectedEntities[targetIndex];
+
+    relationships = relationships.filter(relationship => {
+        return !(relationship.source_entity === sourceEntity.entity
+            && relationship.target_entity === targetEntity.entity);
+    });
+
+    bootstrap.Modal.getInstance(document.getElementById('labModal'))?.hide();
+    renderSelectedEntities();
+}
+
+document.addEventListener('change', function(event) {
+    if (event.target.classList.contains('business-primary-field-check')) {
+        const entityIndex = Number(event.target.dataset.entityIndex);
+        const fieldName = event.target.dataset.fieldName;
+        const selectedEntity = selectedEntities[entityIndex];
+        const sourceEntity = findEntity(selectedEntity.entity_uid);
+        const sourceField = (sourceEntity?.fields || []).find(field => getFieldName(field) === fieldName);
+
+        if (!sourceField) {
+            return;
+        }
+
+        selectedEntity.fields = selectedEntity.fields || [];
+
+        if (event.target.checked && !fieldIsSelected(selectedEntity, fieldName)) {
+            selectedEntity.fields.push(formatPrimaryField(sourceField));
+        }
+
+        if (!event.target.checked) {
+            selectedEntity.fields = selectedEntity.fields.filter(field => getFieldName(field) !== fieldName);
+        }
+
+        syncFieldMappingInput();
+        openEntityUid = selectedEntity.entity_uid;
+        renderSelectedEntities();
+        return;
+    }
+
+    if (event.target.classList.contains('business-meta-field-check')) {
+        const entityIndex = Number(event.target.dataset.entityIndex);
+        const metaKey = event.target.dataset.metaKey;
+        const selectedEntity = selectedEntities[entityIndex];
+        const sourceEntity = findEntity(selectedEntity.entity_uid);
+        const sourceField = (sourceEntity?.meta_fields || []).find(field => getMetaFieldKey(field) === metaKey);
+
+        if (!sourceField) {
+            return;
+        }
+
+        selectedEntity.meta_fields = selectedEntity.meta_fields || [];
+
+        if (event.target.checked && !metaFieldIsSelected(selectedEntity, metaKey)) {
+            selectedEntity.meta_fields.push(formatMetaField(sourceField));
+        }
+
+        if (!event.target.checked) {
+            selectedEntity.meta_fields = selectedEntity.meta_fields.filter(field => getMetaFieldKey(field) !== metaKey);
+        }
+
+        syncFieldMappingInput();
+        openEntityUid = selectedEntity.entity_uid;
+        renderSelectedEntities();
+    }
+});
+
+document.addEventListener('click', function(event) {
+    const removeButton = event.target.closest('.remove-business-entity-item');
+    if (!removeButton) {
+        return;
+    }
+
+    const entityIndex = Number(removeButton.dataset.entityIndex);
+    const removedEntityUid = selectedEntities[entityIndex]?.entity_uid;
+    const removedEntityName = selectedEntities[entityIndex]?.entity;
+    selectedEntities.splice(entityIndex, 1);
+    removeRelationshipsForEntity(removedEntityName);
+    selectedEntities = selectedEntities.map((selectedEntity, index) => ({
+        ...selectedEntity,
+        sort_order: index + 1
+    }));
+
+    if (selectedEntities.length && !selectedEntities.some(selectedEntity => selectedEntity.is_primary)) {
+        selectedEntities[0].is_primary = true;
+    }
+
+    if (openEntityUid === removedEntityUid) {
+        openEntityUid = selectedEntities[entityIndex]?.entity_uid
+            || selectedEntities[entityIndex - 1]?.entity_uid
+            || selectedEntities[0]?.entity_uid
+            || null;
+    }
+
+    renderSelectedEntities();
+});
+
+document.addEventListener('click', function(event) {
+    const addButton = event.target.closest('.add-business-entity-item');
+    if (addButton) {
+        showAddEntityModal();
+        return;
+    }
+
+    const relationshipButton = event.target.closest('.edit-business-relationship');
+    if (!relationshipButton) {
+        return;
+    }
+
+    showRelationshipModal(
+        Number(relationshipButton.dataset.sourceIndex),
+        Number(relationshipButton.dataset.targetIndex)
+    );
+});
+
+document.addEventListener('shown.bs.collapse', function(event) {
+    if (!event.target.id.startsWith('businessEntityItem')) {
+        return;
+    }
+
+    const entityIndex = Number(event.target.id.replace('businessEntityItem', ''));
+    openEntityUid = selectedEntities[entityIndex]?.entity_uid || openEntityUid;
+});
+
+document.getElementById('businessEntityForm').addEventListener('submit', function(event) {
+    syncFieldMappingInput();
+
+    if (!selectedEntities.length) {
+        event.preventDefault();
+        alert('Please add at least one entity.');
+    }
+});
+
+selectedEntities = selectedEntities.map(normalizeStoredEntity);
+renderSelectedEntities();
+</script>
+@endpush

--- a/resources/views/business_entity/index.blade.php
+++ b/resources/views/business_entity/index.blade.php
@@ -1,69 +1,385 @@
 @extends('userinterface::layouts.app')
 
 @section('content')
-<div>
-    <div class="d-flex justify-content-between align-items-center mb-2">
-        <h5 class="fs-6 text-muted">Total {{ $businessEntities->count() }} Business Entities</h5>
-        <a href="{{ route('business-entities.create') }}" class="btn btn-sm btn-outline-primary">
-            <i class="fa-regular fa-fw fa-plus"></i>
-            <span class="d-none d-md-inline-block ms-1">Business Entity</span>
-        </a>
-    </div>
+    @php
+        $businessEntityMappings = $businessEntities->mapWithKeys(function ($businessEntity) {
+            $fieldMapping = $businessEntity->field_mapping ?? [];
 
-    <div class="table-responsive">
-        <table id="business-entities-table" class="table table-striped table-hover">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Status</th>
-                    <th>Created At</th>
-                    <th>Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach($businessEntities as $businessEntity)
+            if (is_string($fieldMapping)) {
+                $fieldMapping = json_decode($fieldMapping, true) ?: [];
+            }
+
+            return [
+                $businessEntity->uid => [
+                    'name' => $businessEntity->business_entity_name,
+                    'uid' => $businessEntity->uid,
+                    'mapping' => $fieldMapping,
+                ],
+            ];
+        });
+    @endphp
+
+    <div>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h5 class="fs-6 text-muted">Total {{ $businessEntities->count() }} Business Entities</h5>
+            <a href="{{ route('business-entities.create') }}" class="btn btn-sm btn-outline-primary">
+                <i class="fa-regular fa-fw fa-plus"></i>
+                <span class="d-none d-md-inline-block ms-1">Business Entity</span>
+            </a>
+        </div>
+
+        <div class="table-responsive">
+            <table id="business-entities-table" class="table table-striped table-hover">
+                <thead>
                     <tr>
-                        <td>
-                            <a href="{{ route('business-entities.edit', $businessEntity->uid) }}" class="text-decoration-none">
-                                {{ $businessEntity->business_entity_name }}
-                            </a>
-                            <br>
-                            <small><small class="text-muted">{{ $businessEntity->uid }}</small></small>
-                        </td>
-                        <td>
-                            <x-userinterface::status :status="$businessEntity->status" />
-                        </td>
-                        <td>{{ $businessEntity->created_at->format('d M Y') }}</td>
-                        <td>
-                            <div class="d-flex align-content-center justify-content-center gap-2">
-                                <a class="btn btn-sm btn-outline-dark" href="{{ route('business-entities.edit', $businessEntity->uid) }}">
-                                    <i class="fas fa-fw fa-edit"></i>
-                                </a>
-
-                                <form action="{{ route('business-entities.destroy', $businessEntity->uid) }}" method="POST" onsubmit="return confirm('Are you sure?')">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-sm btn-outline-danger">
-                                        <i class="fas fa-fw fa-trash"></i>
-                                    </button>
-                                </form>
-                            </div>
-                        </td>
+                        <th>Name</th>
+                        <th>Status</th>
+                        <th>Created At</th>
+                        <th>Actions</th>
                     </tr>
-                @endforeach
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    @foreach ($businessEntities as $businessEntity)
+                        <tr>
+                            <td>
+                                <a href="{{ route('business-entities.edit', $businessEntity->uid) }}"
+                                    class="text-decoration-none">
+                                    {{ $businessEntity->business_entity_name }}
+                                </a>
+                                <br>
+                                <small><small class="text-muted">{{ $businessEntity->uid }}</small></small>
+                            </td>
+                            <td>
+                                <x-userinterface::status :status="$businessEntity->status" />
+                            </td>
+                            <td>{{ $businessEntity->created_at->format('d M Y') }}</td>
+                            <td>
+                                <div class="d-flex align-content-center justify-content-center gap-2">
+                                    <button type="button"
+                                        class="btn btn-sm btn-outline-secondary view-business-entity-details"
+                                        data-business-entity-uid="{{ $businessEntity->uid }}">
+                                        <i class="fa-solid fa-fw fa-diagram-project"></i>
+                                    </button>
+
+                                    <a class="btn btn-sm btn-outline-dark"
+                                        href="{{ route('business-entities.edit', $businessEntity->uid) }}">
+                                        <i class="fas fa-fw fa-edit"></i>
+                                    </a>
+
+                                    <form action="{{ route('business-entities.destroy', $businessEntity->uid) }}"
+                                        method="POST" onsubmit="return confirm('Are you sure?')">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">
+                                            <i class="fas fa-fw fa-trash"></i>
+                                        </button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
     </div>
-</div>
 @endsection
 
+@push('styles')
+    <style>
+        .business-entity-tree,
+        .business-entity-tree ul,
+        .business-entity-tree li {
+            list-style: none;
+            margin: 0;
+            padding-left: 0;
+        }
+
+        .business-entity-tree {
+            min-width: max-content;
+        }
+
+        .business-entity-tree .tree-item {
+            position: relative;
+            margin-bottom: 4px;
+        }
+
+        .business-entity-tree .tree-item-content {
+            padding: 4px 8px;
+            border-radius: 4px;
+        }
+
+        .business-entity-tree .tree-item-children {
+            margin-left: 25px;
+            margin-top: 4px;
+            position: relative;
+        }
+
+        .business-entity-tree .tree-item-children::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: -4px;
+            bottom: 20px;
+            width: 1px;
+            border-left: 1px solid #adb5bd;
+        }
+
+        .business-entity-tree .tree-item-children .tree-item::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 18px;
+            width: 20px;
+            border-top: 1px solid #adb5bd;
+        }
+
+        .business-entity-tree .tree-item-children .tree-item-content {
+            padding-left: 25px;
+        }
+
+        .business-entity-tree .tree-item-value {
+            color: #6c757d;
+            margin-left: 6px;
+        }
+
+        .business-entity-tree-header {
+            padding: 4px 8px;
+        }
+
+        .business-entity-sequence {
+            margin-left: 25px;
+            position: relative;
+        }
+
+        .business-entity-sequence::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 18px;
+            bottom: 20px;
+            width: 1px;
+            border-left: 1px solid #adb5bd;
+        }
+
+        .business-entity-sequence>.tree-item::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 18px;
+            width: 20px;
+            border-top: 1px solid #adb5bd;
+        }
+
+        .business-entity-sequence>.tree-item>.tree-item-content {
+            padding-left: 25px;
+        }
+    </style>
+@endpush
+
 @push('scripts')
-<script>
-    $(document).ready(function() {
-        $('#business-entities-table').DataTable({
-            responsive: true,
-            order: [[2, 'desc']]
+    <script>
+        const businessEntityMappings = @json($businessEntityMappings);
+
+        function escapeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        function getMappingFieldName(field) {
+            return field.field || field.name || field.meta_key || '';
+        }
+
+        function getMappingMetaFieldName(field) {
+            return field.meta_key || field.field || field.name || '';
+        }
+
+        function getDisplayMetaFieldName(field) {
+            const metaFieldName = getMappingMetaFieldName(field);
+
+            return metaFieldName.startsWith('m_') ?
+                metaFieldName :
+                `m_${metaFieldName}`;
+        }
+
+
+        function normalizeRelationship(relationship) {
+            return {
+                source_entity: relationship.source_entity || relationship.from_entity || '',
+                target_entity: relationship.target_entity || relationship.to_entity || '',
+                type: relationship.type || relationship.relation_type || '',
+                source_key: relationship.source_key || relationship.from_field || '',
+                target_key: relationship.target_key || relationship.to_field || ''
+            };
+        }
+
+        function normalizeMapping(mapping = {}) {
+            return {
+                primary_entity: mapping.primary_entity || null,
+                entities: Array.isArray(mapping.entities) ? mapping.entities : [],
+                relationships: Array.isArray(mapping.relationships) ?
+                    mapping.relationships.map(normalizeRelationship) : []
+            };
+        }
+
+        function renderTreeNode(label, value = '', children = '', icon = 'fa-circle') {
+            return `
+            <li class="tree-item">
+                <div class="tree-item-content">
+                    <i class="fas fa-fw ${icon} text-muted me-1"></i>
+                    <span class="tree-item-key">${escapeHtml(label)}</span>
+                    ${value ? `<span class="tree-item-value">- ${escapeHtml(value)}</span>` : ''}
+                </div>
+                ${children ? `<ul class="tree-item-children">${children}</ul>` : ''}
+            </li>
+        `;
+        }
+
+        function renderFieldTree(fields, emptyLabel) {
+            if (!fields.length) {
+                return renderTreeNode(emptyLabel, '', '', 'fa-minus');
+            }
+
+            return fields.map(field => renderTreeNode(
+                getMappingFieldName(field),
+                [field.label, field.type].filter(Boolean).join(' | '),
+                '',
+                'fa-table-columns'
+            )).join('');
+        }
+
+        function renderMetaFieldTree(fields) {
+            return fields.map(field => renderTreeNode(
+                getDisplayMetaFieldName(field),
+                [field.label, field.type].filter(Boolean).join(' | '),
+                '',
+                'fa-tags'
+            )).join('');
+        }
+
+        function findRelationshipsBetween(sourceEntity, targetEntity, relationships) {
+            return relationships.filter(relationship => {
+                return (
+                    relationship.source_entity === sourceEntity.entity &&
+                    relationship.target_entity === targetEntity.entity
+                ) || (
+                    relationship.source_entity === targetEntity.entity &&
+                    relationship.target_entity === sourceEntity.entity
+                );
+            });
+        }
+
+        function renderRelationshipConnector(sourceEntity, targetEntity, relationships) {
+            const matchingRelationships = findRelationshipsBetween(sourceEntity, targetEntity, relationships);
+
+            if (!matchingRelationships.length) {
+                return renderTreeNode(
+                    `${sourceEntity.entity || 'source'} -> ${targetEntity.entity || 'target'}`,
+                    'No relationship configured',
+                    '',
+                    'fa-link'
+                );
+            }
+
+            return matchingRelationships.map(relationship => {
+                const relationLabel =
+                    `${relationship.source_entity || 'source'} -> ${relationship.target_entity || 'target'}`;
+                const relationValue = [
+                    relationship.type,
+                    relationship.source_key && relationship.target_key ?
+                    `${relationship.source_key} -> ${relationship.target_key}` :
+                    ''
+                ].filter(Boolean).join(' | ');
+
+                return renderTreeNode(relationLabel, relationValue, '', 'fa-link');
+            }).join('');
+        }
+
+        function renderBusinessEntityTree(mapping) {
+            const mappingRelationships = mapping.relationships || [];
+            const entityNodes = (mapping.entities || []).map((entity, index) => {
+                const entityFields = [
+                    renderFieldTree(entity.fields || [], 'No fields selected'),
+                    renderMetaFieldTree(entity.meta_fields || [])
+                ].join('');
+                const entityNode = renderTreeNode(
+                    entity.entity || 'Unnamed entity',
+                    entity.is_primary ? 'Primary' : '',
+                    entityFields || renderTreeNode('No fields selected', '', '', 'fa-minus'),
+                    entity.is_primary ? 'fa-star' : 'fa-table'
+                );
+                const nextEntity = (mapping.entities || [])[index + 1];
+
+                if (!nextEntity) {
+                    return entityNode;
+                }
+
+                return entityNode + renderTreeNode(
+                    'Relationship',
+                    '',
+                    renderRelationshipConnector(entity, nextEntity, mappingRelationships),
+                    'fa-diagram-project'
+                );
+            }).join('');
+
+            return `
+        <div class="overflow-auto bg-light border rounded p-2" style="max-height: 60vh;">
+            <div class="business-entity-tree-header">
+                <i class="fas fa-fw fa-sitemap text-muted me-1"></i>
+                <span class="tree-item-key">Selected Entities / Tables</span>
+                <span class="tree-item-value">- ${(mapping.entities || []).length} selected</span>
+            </div>
+            <ul class="business-entity-tree business-entity-sequence">
+                ${entityNodes || renderTreeNode('No entities selected', '', '', 'fa-minus')}
+            </ul>
+        </div>
+    `;
+        }
+
+        function showBusinessEntityDetails(uid) {
+            const businessEntity = businessEntityMappings[uid];
+
+            if (!businessEntity) {
+                return;
+            }
+
+            const modalBody = document.createElement('div');
+            modalBody.innerHTML = renderBusinessEntityTree(businessEntity.mapping || {});
+
+            showModal({
+                header: {
+                    enabled: true,
+                    content: `
+                    <h5 class="modal-title">${escapeHtml(businessEntity.name)}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                `,
+                },
+                body: {
+                    enabled: true,
+                    content: modalBody,
+                },
+                footer: {
+                    enabled: true,
+                    allowCancel: true,
+                    actions: [],
+                },
+            });
+        }
+
+        $(document).ready(function() {
+            $('#business-entities-table').DataTable({
+                responsive: true,
+                order: [
+                    [2, 'desc']
+                ]
+            });
+
+            $(document).on('click', '.view-business-entity-details', function() {
+                showBusinessEntityDetails($(this).data('business-entity-uid'));
+            });
         });
-    });
-</script>
+    </script>
 @endpush

--- a/resources/views/business_entity/index.blade.php
+++ b/resources/views/business_entity/index.blade.php
@@ -298,9 +298,25 @@
             }).join('');
         }
 
+        function renderAssociationConnector(associationEntity) {
+            return renderTreeNode(
+                `Association: ${associationEntity.entity}`,
+                '',
+                renderFieldTree(
+                    associationEntity.fields || [],
+                    'No fields available'
+                ),
+                'fa-link'
+            );
+        }
+
         function renderBusinessEntityTree(mapping) {
             const mappingRelationships = mapping.relationships || [];
             const entityNodes = (mapping.entities || []).map((entity, index) => {
+                if (entity.is_association) {
+                    return '';
+                }
+
                 const entityFields = [
                     renderFieldTree(entity.fields || [], 'No fields selected'),
                     renderMetaFieldTree(entity.meta_fields || [])
@@ -315,6 +331,11 @@
 
                 if (!nextEntity) {
                     return entityNode;
+                }
+
+                if (nextEntity.is_association) {
+                    return entityNode +
+                        renderAssociationConnector(nextEntity);
                 }
 
                 return entityNode + renderTreeNode(

--- a/resources/views/business_entity/index.blade.php
+++ b/resources/views/business_entity/index.blade.php
@@ -1,0 +1,69 @@
+@extends('userinterface::layouts.app')
+
+@section('content')
+<div>
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <h5 class="fs-6 text-muted">Total {{ $businessEntities->count() }} Business Entities</h5>
+        <a href="{{ route('business-entities.create') }}" class="btn btn-sm btn-outline-primary">
+            <i class="fa-regular fa-fw fa-plus"></i>
+            <span class="d-none d-md-inline-block ms-1">Business Entity</span>
+        </a>
+    </div>
+
+    <div class="table-responsive">
+        <table id="business-entities-table" class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Status</th>
+                    <th>Created At</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($businessEntities as $businessEntity)
+                    <tr>
+                        <td>
+                            <a href="{{ route('business-entities.edit', $businessEntity->uid) }}" class="text-decoration-none">
+                                {{ $businessEntity->business_entity_name }}
+                            </a>
+                            <br>
+                            <small><small class="text-muted">{{ $businessEntity->uid }}</small></small>
+                        </td>
+                        <td>
+                            <x-userinterface::status :status="$businessEntity->status" />
+                        </td>
+                        <td>{{ $businessEntity->created_at->format('d M Y') }}</td>
+                        <td>
+                            <div class="d-flex align-content-center justify-content-center gap-2">
+                                <a class="btn btn-sm btn-outline-dark" href="{{ route('business-entities.edit', $businessEntity->uid) }}">
+                                    <i class="fas fa-fw fa-edit"></i>
+                                </a>
+
+                                <form action="{{ route('business-entities.destroy', $businessEntity->uid) }}" method="POST" onsubmit="return confirm('Are you sure?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">
+                                        <i class="fas fa-fw fa-trash"></i>
+                                    </button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+    $(document).ready(function() {
+        $('#business-entities-table').DataTable({
+            responsive: true,
+            order: [[2, 'desc']]
+        });
+    });
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,7 +45,7 @@ Route::middleware('web')->group(function () {
             Route::put('/{businessEntityUid}', [BusinessEntityController::class, 'update'])->name('update');
             Route::delete('/{businessEntityUid}', [BusinessEntityController::class, 'destroy'])->name('destroy');
         });
-        
+
         // Module-Role assignment routes
         Route::get('/modules/assign-to-role', [ModuleController::class, 'assignToRole'])->name('modules.assign-to-role');
         Route::put('/modules/{role}/assign', [ModuleController::class, 'updateRoleModules'])->name('modules.update-role-modules');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Iquesters\Foundation\Http\Controllers\BusinessEntityController;
 use Iquesters\Foundation\Http\Controllers\ConfigController;
 use Iquesters\Foundation\Http\Controllers\EntityController;
 use Iquesters\Foundation\Http\Controllers\MasterDataController;
@@ -33,6 +34,16 @@ Route::middleware('web')->group(function () {
             Route::delete('/{entityUid}', [EntityController::class, 'destroy'])->name('destroy');
             Route::post('/{entityUid}/publish', [EntityController::class, 'publish'])->name('publish');
             Route::get('/{entityUid}', [EntityController::class, 'show'])->name('show');
+        });
+
+        Route::prefix('business-entity')->name('business-entities.')->group(function () {
+            Route::get('/', [BusinessEntityController::class, 'index'])->name('index');
+            Route::get('/create', [BusinessEntityController::class, 'create'])->name('create');
+            Route::get('/entity-options', [BusinessEntityController::class, 'entityOptions'])->name('entity-options');
+            Route::post('/', [BusinessEntityController::class, 'store'])->name('store');
+            Route::get('/{businessEntityUid}/edit', [BusinessEntityController::class, 'edit'])->name('edit');
+            Route::put('/{businessEntityUid}', [BusinessEntityController::class, 'update'])->name('update');
+            Route::delete('/{businessEntityUid}', [BusinessEntityController::class, 'destroy'])->name('destroy');
         });
         
         // Module-Role assignment routes

--- a/src/Http/Controllers/BusinessEntityController.php
+++ b/src/Http/Controllers/BusinessEntityController.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Iquesters\Foundation\Http\Controllers;
+
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Iquesters\Foundation\Models\BusinessEntity;
+use Iquesters\Foundation\Models\Entity;
+use Iquesters\Foundation\Models\Module;
+
+class BusinessEntityController extends Controller
+{
+    public function index()
+    {
+        try {
+            $businessEntities = BusinessEntity::query()->get();
+
+            return view('foundation::business_entity.index', [
+                'businessEntities' => $businessEntities,
+            ]);
+        } catch (Exception $e) {
+            Log::error('Error fetching business entities', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return redirect()
+                ->back()
+                ->with('error', 'An error occurred while fetching business entities.');
+        }
+    }
+
+    public function create()
+    {
+        $modules = Module::where('status', 'active')->get();
+        $entities = Entity::where('status', 'active')->get();
+
+        return view('foundation::business_entity.create-edit', [
+            'businessEntity' => null,
+            'isCreating' => true,
+            'modules' => $modules,
+            'entities' => $entities,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        try {
+            $validated = $request->validate([
+                'business_entity_name' => 'required|string|max:255|unique:business_entities,business_entity_name',
+                'ref_module' => 'required|exists:modules,id',
+                'desc' => 'nullable|string',
+                'field_mapping' => 'required|json',
+            ]);
+
+            $businessEntity = BusinessEntity::create([
+                'uid' => (string) Str::ulid(),
+                'ref_module' => $validated['ref_module'],
+                'business_entity_name' => $validated['business_entity_name'],
+                'slug' => $this->generateUniqueSlug($validated['business_entity_name']),
+                'desc' => $validated['desc'] ?? null,
+                'field_mapping' => json_decode($validated['field_mapping'], true),
+                'status' => 'active',
+                'created_by' => auth()->id() ?? 0,
+                'updated_by' => auth()->id() ?? 0,
+            ]);
+
+            return redirect()
+                ->route('business-entities.edit', $businessEntity->uid)
+                ->with('success', 'Business Entity created successfully.');
+        } catch (Exception $e) {
+            Log::error('Error creating business entity', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return redirect()
+                ->back()
+                ->withInput()
+                ->with('error', $e->getMessage());
+        }
+    }
+
+    public function edit(string $businessEntityUid)
+    {
+        try {
+            $businessEntity = BusinessEntity::where('uid', $businessEntityUid)->firstOrFail();
+            $modules = Module::where('status', 'active')->get();
+            $entities = Entity::where('status', 'active')->get();
+
+            return view('foundation::business_entity.create-edit', [
+                'businessEntity' => $businessEntity,
+                'isCreating' => false,
+                'modules' => $modules,
+                'entities' => $entities,
+            ]);
+        } catch (Exception $e) {
+            Log::error('Error loading business entity edit form', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return redirect()
+                ->route('business-entities.index')
+                ->with('error', 'An error occurred while loading the business entity.');
+        }
+    }
+
+    public function update(Request $request, string $businessEntityUid)
+    {
+        try {
+            $businessEntity = BusinessEntity::where('uid', $businessEntityUid)->firstOrFail();
+
+            $validated = $request->validate([
+                'business_entity_name' => 'required|string|max:255|unique:business_entities,business_entity_name,' . $businessEntity->id,
+                'ref_module' => 'required|exists:modules,id',
+                'desc' => 'nullable|string',
+                'field_mapping' => 'required|json',
+            ]);
+
+            $businessEntity->update([
+                'ref_module' => $validated['ref_module'],
+                'business_entity_name' => $validated['business_entity_name'],
+                'desc' => $validated['desc'] ?? null,
+                'field_mapping' => json_decode($validated['field_mapping'], true),
+                'updated_by' => auth()->id() ?? 0,
+            ]);
+
+            return redirect()
+                ->route('business-entities.edit', $businessEntity->uid)
+                ->with('success', 'Business Entity updated successfully.');
+        } catch (Exception $e) {
+            Log::error('Error updating business entity', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return redirect()
+                ->back()
+                ->withInput()
+                ->with('error', $e->getMessage());
+        }
+    }
+
+    public function destroy(string $businessEntityUid)
+    {
+        try {
+            $businessEntity = BusinessEntity::where('uid', $businessEntityUid)->firstOrFail();
+
+            $businessEntity->update([
+                'status' => 'deleted',
+                'updated_by' => auth()->id() ?? 0,
+            ]);
+
+            return redirect()
+                ->route('business-entities.index')
+                ->with('success', 'Business Entity deleted successfully.');
+        } catch (Exception $e) {
+            Log::error('Error deleting business entity', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return redirect()
+                ->back()
+                ->with('error', $e->getMessage());
+        }
+    }
+
+    public function entityOptions()
+    {
+        $entities = Entity::where('status', 'active')
+            ->get()
+            ->map(function (Entity $entity) {
+                return [
+                    'uid' => $entity->uid,
+                    'entity_name' => $entity->entity_name,
+                    'slug' => $entity->slug,
+                    'fields' => $entity->fields ?? [],
+                    'meta_fields' => $entity->meta_fields ?? [],
+                ];
+            });
+
+        return response()->json([
+            'data' => $entities,
+        ]);
+    }
+
+    private function generateUniqueSlug(string $businessEntityName): string
+    {
+        $baseSlug = strtolower($businessEntityName);
+        $baseSlug = preg_replace('/[^a-z0-9]+/', '-', $baseSlug);
+        $baseSlug = trim($baseSlug, '-');
+
+        $slug = $baseSlug;
+        $counter = 1;
+
+        while (BusinessEntity::where('slug', $slug)->exists()) {
+            $slug = $baseSlug . '-' . $counter;
+            $counter++;
+        }
+
+        return $slug;
+    }
+}

--- a/src/Http/Controllers/BusinessEntityController.php
+++ b/src/Http/Controllers/BusinessEntityController.php
@@ -36,7 +36,9 @@ class BusinessEntityController extends Controller
     public function create()
     {
         $modules = Module::where('status', 'active')->get();
-        $entities = Entity::where('status', 'active')->get();
+        $entities = Entity::with('metas')
+            ->where('status', 'active')
+            ->get();
 
         return view('foundation::business_entity.create-edit', [
             'businessEntity' => null,
@@ -89,7 +91,9 @@ class BusinessEntityController extends Controller
         try {
             $businessEntity = BusinessEntity::where('uid', $businessEntityUid)->firstOrFail();
             $modules = Module::where('status', 'active')->get();
-            $entities = Entity::where('status', 'active')->get();
+            $entities = Entity::with('metas')
+                ->where('status', 'active')
+                ->get();
 
             return view('foundation::business_entity.create-edit', [
                 'businessEntity' => $businessEntity,

--- a/src/Http/Controllers/BusinessEntityController.php
+++ b/src/Http/Controllers/BusinessEntityController.php
@@ -10,9 +10,20 @@ use Illuminate\Support\Str;
 use Iquesters\Foundation\Models\BusinessEntity;
 use Iquesters\Foundation\Models\Entity;
 use Iquesters\Foundation\Models\Module;
+use Iquesters\Foundation\Services\FormSchemaService;
+use Iquesters\Foundation\Services\TableSchemaService;
+use Iquesters\Foundation\System\Traits\Loggable;
 
 class BusinessEntityController extends Controller
 {
+    use Loggable;
+
+    public function __construct(
+        private FormSchemaService $formSchemaService,
+        private TableSchemaService $tableSchemaService
+    ) {
+    }
+
     public function index()
     {
         try {
@@ -58,21 +69,55 @@ class BusinessEntityController extends Controller
                 'field_mapping' => 'required|json',
             ]);
 
+            $fieldMapping = json_decode($validated['field_mapping'], true);
+            $slug = $this->generateUniqueSlug($validated['business_entity_name']);
+            $tableName = $this->generateTableName($validated['business_entity_name']);
+
+            $this->logInfo('Creating business entity ' . $validated['business_entity_name']);
+
             $businessEntity = BusinessEntity::create([
                 'uid' => (string) Str::ulid(),
                 'ref_module' => $validated['ref_module'],
                 'business_entity_name' => $validated['business_entity_name'],
-                'slug' => $this->generateUniqueSlug($validated['business_entity_name']),
+                'slug' => $slug,
                 'desc' => $validated['desc'] ?? null,
-                'field_mapping' => json_decode($validated['field_mapping'], true),
+                'field_mapping' => $fieldMapping,
                 'status' => 'active',
                 'created_by' => auth()->id() ?? 0,
                 'updated_by' => auth()->id() ?? 0,
             ]);
 
+            [$customFields, $metaFields] = $this->buildSchemaFieldsFromMapping($fieldMapping);
+            $this->saveBusinessEntityMeta($businessEntity, 'table_name', $tableName);
+
+            $this->logInfo('Generating schemas for business entity ' . $businessEntity->business_entity_name);
+
+            $schemaOptions = ['is_business_entity' => true];
+            $formSchemaUid = $this->formSchemaService->createAndAttach(
+                $businessEntity,
+                $slug,
+                $customFields,
+                $metaFields,
+                $schemaOptions
+            );
+            $tableSchemaUid = $this->tableSchemaService->createAndAttach(
+                $businessEntity,
+                $slug,
+                $customFields,
+                $formSchemaUid,
+                $metaFields,
+                $schemaOptions
+            );
+
+            Log::info('Business entity created with schemas', [
+                'business_entity_uid' => $businessEntity->uid,
+                'form_schema_uid' => $formSchemaUid,
+                'table_schema_uid' => $tableSchemaUid,
+            ]);
+
             return redirect()
                 ->route('business-entities.edit', $businessEntity->uid)
-                ->with('success', 'Business Entity created successfully.');
+                ->with('success', 'Business Entity created successfully with form and table schemas.');
         } catch (Exception $e) {
             Log::error('Error creating business entity', [
                 'error' => $e->getMessage(),
@@ -132,6 +177,25 @@ class BusinessEntityController extends Controller
                 'field_mapping' => json_decode($validated['field_mapping'], true),
                 'updated_by' => auth()->id() ?? 0,
             ]);
+
+            [$customFields, $metaFields] = $this->buildSchemaFieldsFromMapping($validated['field_mapping']);
+            $schemaOptions = ['is_business_entity' => true];
+
+            $formSchemaUid = $this->formSchemaService->ensureGenerated(
+                $businessEntity,
+                $customFields,
+                $metaFields,
+                $schemaOptions
+            );
+
+            $this->tableSchemaService->ensureGenerated(
+                $businessEntity,
+                $businessEntity->slug,
+                $customFields,
+                $formSchemaUid,
+                $metaFields,
+                $schemaOptions
+            );
 
             return redirect()
                 ->route('business-entities.edit', $businessEntity->uid)
@@ -193,6 +257,143 @@ class BusinessEntityController extends Controller
         ]);
     }
 
+    public function buildSchemaFieldsFromMapping(mixed $fieldMapping): array
+    {
+        if (is_string($fieldMapping)) {
+            $fieldMapping = json_decode($fieldMapping, true) ?: [];
+        }
+
+        $customFields = [];
+        $metaFields = [];
+        $entities = $fieldMapping['entities'] ?? [];
+
+        if (! is_array($entities)) {
+            return [$customFields, $metaFields];
+        }
+
+        usort($entities, function ($left, $right) {
+            return ($left['sort_order'] ?? 0) <=> ($right['sort_order'] ?? 0);
+        });
+
+        foreach ($entities as $mappedEntity) {
+            if (! is_array($mappedEntity)) {
+                continue;
+            }
+
+            $prefix = $this->resolveMappingPrefix($mappedEntity);
+            $entityLabel = $mappedEntity['entity'] ?? $prefix;
+
+            foreach (($mappedEntity['fields'] ?? []) as $field) {
+                if (! is_array($field)) {
+                    continue;
+                }
+
+                $fieldName = $field['field'] ?? $field['name'] ?? null;
+
+                if (! $fieldName) {
+                    continue;
+                }
+
+                $schemaFieldName = $this->normalizeSchemaFieldName($prefix . '_' . $fieldName);
+                $fieldType = $field['type'] ?? 'string';
+
+                $customFields[$schemaFieldName] = [
+                    'name' => $schemaFieldName,
+                    'type' => $fieldType,
+                    'label' => trim(($entityLabel ? $entityLabel . ' ' : '') . ($field['label'] ?? Str::headline($fieldName))),
+                    'required' => $field['required'] ?? false,
+                    'nullable' => $field['nullable'] ?? true,
+                    'input_type' => $field['input_type'] ?? $this->resolveInputType($fieldType),
+                    'maxlength' => $field['maxlength'] ?? null,
+                    'default' => $field['default'] ?? null,
+                    'source_entity' => $mappedEntity['entity'] ?? null,
+                    'source_field' => $fieldName,
+                ];
+            }
+
+            foreach (($mappedEntity['meta_fields'] ?? []) as $field) {
+                if (! is_array($field)) {
+                    continue;
+                }
+
+                $metaKey = $field['meta_key'] ?? $field['field'] ?? $field['name'] ?? null;
+
+                if (! $metaKey) {
+                    continue;
+                }
+
+                $schemaMetaKey = $this->normalizeSchemaFieldName($prefix . '_m_' . $metaKey);
+                $fieldType = $field['type'] ?? 'string';
+
+                $metaFields[] = [
+                    'meta_key' => $schemaMetaKey,
+                    'label' => trim(($entityLabel ? $entityLabel . ' ' : '') . ($field['label'] ?? Str::headline($metaKey))),
+                    'type' => $fieldType,
+                    'input_type' => $field['input_type'] ?? $this->resolveInputType($fieldType),
+                    'required' => $field['required'] ?? false,
+                    'nullable' => $field['nullable'] ?? true,
+                    'display' => $field['display'] ?? true,
+                    'source_entity' => $mappedEntity['entity'] ?? null,
+                    'source_meta_key' => $metaKey,
+                ];
+            }
+        }
+
+        return [$customFields, $metaFields];
+    }
+
+    private function resolveMappingPrefix(array $mappedEntity): string
+    {
+        return $this->normalizeSchemaFieldName(
+            $mappedEntity['slug']
+            ?? $mappedEntity['entity']
+            ?? $mappedEntity['entity_uid']
+            ?? 'entity'
+        );
+    }
+
+    private function normalizeSchemaFieldName(string $fieldName): string
+    {
+        $fieldName = strtolower($fieldName);
+        $fieldName = preg_replace('/[^a-z0-9]+/', '_', $fieldName);
+
+        return trim($fieldName, '_');
+    }
+
+    private function resolveInputType(string $fieldType): string
+    {
+        return match ($fieldType) {
+            'text', 'longtext' => 'textarea',
+            'integer', 'bigint', 'decimal' => 'number',
+            'date' => 'date',
+            'datetime', 'timestamp' => 'datetime-local',
+            'time' => 'time',
+            'boolean' => 'checkbox',
+            default => 'text',
+        };
+    }
+
+    private function saveBusinessEntityMeta(BusinessEntity $businessEntity, string $metaKey, mixed $metaValue): void
+    {
+        $businessEntity->metas()->updateOrCreate(
+            ['meta_key' => $metaKey],
+            [
+                'meta_value' => $metaValue,
+                'status' => 'active',
+                'created_by' => auth()->id(),
+                'updated_by' => auth()->id(),
+            ]
+        );
+    }
+
+    private function generateTableName(string $businessEntityName): string
+    {
+        $tableName = strtolower($businessEntityName);
+        $tableName = preg_replace('/[^a-z0-9]+/', '_', $tableName);
+
+        return trim($tableName, '_');
+    }
+
     private function generateUniqueSlug(string $businessEntityName): string
     {
         $baseSlug = strtolower($businessEntityName);
@@ -209,4 +410,5 @@ class BusinessEntityController extends Controller
 
         return $slug;
     }
+
 }

--- a/src/Http/Controllers/EntityController.php
+++ b/src/Http/Controllers/EntityController.php
@@ -3,20 +3,25 @@
 namespace Iquesters\Foundation\Http\Controllers;
 
 use Illuminate\Routing\Controller;
-use Iquesters\Foundation\Constants\EntityStatus;
 use Iquesters\Foundation\Models\Entity;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Log;
-use Iquesters\UserInterface\Models\FormSchema;
-use Iquesters\UserInterface\Models\TableSchema;
 use Illuminate\Database\Schema\Blueprint;
 use Iquesters\Foundation\Models\Module;
+use Iquesters\Foundation\Services\FormSchemaService;
+use Iquesters\Foundation\Services\TableSchemaService;
 use Illuminate\Support\Facades\Schema;
 use Exception;
 
 class EntityController extends Controller
 {
+    public function __construct(
+        private FormSchemaService $formSchemaService,
+        private TableSchemaService $tableSchemaService
+    ) {
+    }
+
     private const SUPPORTED_PRIMARY_FIELD_TYPES = [
         'string',
         'text',
@@ -155,10 +160,8 @@ class EntityController extends Controller
 
             // Save metadata and generate schemas
             $this->saveEntityMeta($entity, 'table_name', $tableName);
-            $formSchemaUid = $this->createFormSchema($entity, $slug, $processedCustomFields, $metaFieldsData);
-            $this->saveEntityMeta($entity, 'form_schema_uid', $formSchemaUid);
-            $tableSchemaUid = $this->createTableSchema($entity, $slug, $processedCustomFields, $formSchemaUid);
-            $this->saveEntityMeta($entity, 'table_schema_uid', $tableSchemaUid);
+            $formSchemaUid = $this->formSchemaService->createAndAttach($entity, $slug, $processedCustomFields, $metaFieldsData);
+            $tableSchemaUid = $this->tableSchemaService->createAndAttach($entity, $slug, $processedCustomFields, $formSchemaUid);
 
             Log::info('Entity created with schemas', [
                 'entity' => $entity->toArray(),
@@ -229,7 +232,7 @@ class EntityController extends Controller
                 ? $this->extractCustomFieldsFromEntityFields($allFields)
                 : ($processedCustomFields ?? []);
 
-            $this->ensureGeneratedFormSchema($entity, $customFieldsForSchema, $metaFieldsData);
+            $this->formSchemaService->ensureGenerated($entity, $customFieldsForSchema, $metaFieldsData);
 
             Log::info('Entity updated', [
                 'entity_uid' => $entity->uid,
@@ -520,197 +523,6 @@ class EntityController extends Controller
         );
     }
 
-    /**
-     * Create form schema and return its UID
-     */
-    private function createFormSchema($entity, $slug, $customFields, $metaFields = [])
-    {
-        $formSchema = $this->generateFormSchema($entity, $customFields, $metaFields);
-        $formSchemaRecord = FormSchema::create([
-            'uid' => Str::ulid(),
-            'slug' => $slug . '-form',
-            'name' => $entity->entity_name . ' Form',
-            'description' => 'Auto-generated form for ' . $entity->entity_name,
-            'schema' => $formSchema,
-            'extra_info' => [],
-            'status' => EntityStatus::ACTIVE,
-            'created_by' => auth()->id(),
-            'updated_by' => auth()->id(),
-        ]);
-
-        return $formSchemaRecord->uid;
-    }
-
-    private function ensureGeneratedFormSchema($entity, $customFields, $metaFields): void
-    {
-        $formSchemaUid = $entity->getMeta('form_schema_uid');
-        $formSchemaSlug = $entity->slug . '-form';
-
-        if (! $formSchemaUid) {
-            $newFormSchemaUid = $this->createFormSchema($entity, $entity->slug, $customFields, $metaFields);
-            $this->saveEntityMeta($entity, 'form_schema_uid', $newFormSchemaUid, false);
-
-            Log::info('Generated form schema recreated because form_schema_uid was missing', [
-                'entity_uid' => $entity->uid,
-                'form_schema_uid' => $newFormSchemaUid,
-            ]);
-
-            return;
-        }
-
-        $formSchemaRecord = FormSchema::where('uid', $formSchemaUid)->first();
-
-        if (! $formSchemaRecord) {
-            $formSchemaRecord = FormSchema::where('slug', $formSchemaSlug)->first();
-        }
-
-        if (! $formSchemaRecord) {
-            $newFormSchemaUid = $this->createFormSchema($entity, $entity->slug, $customFields, $metaFields);
-            $this->saveEntityMeta($entity, 'form_schema_uid', $newFormSchemaUid, false);
-
-            Log::info('Generated form schema recreated because stored schema record was missing', [
-                'entity_uid' => $entity->uid,
-                'missing_form_schema_uid' => $formSchemaUid,
-                'new_form_schema_uid' => $newFormSchemaUid,
-            ]);
-
-            return;
-        }
-
-        $formSchemaRecord->update([
-            'name' => $entity->entity_name . ' Form',
-            'description' => 'Auto-generated form for ' . $entity->entity_name,
-            'schema' => $this->generateFormSchema($entity, $customFields, $metaFields),
-            'updated_by' => auth()->id(),
-        ]);
-
-        if ($formSchemaRecord->uid !== $formSchemaUid) {
-            $this->saveEntityMeta($entity, 'form_schema_uid', $formSchemaRecord->uid, false);
-        }
-    }
-
-    /**
-     * Create table schema and return its UID
-     */
-    private function createTableSchema($entity, $slug, $customFields, $formSchemaUid)
-    {
-        $tableSchema = $this->generateTableSchema($entity, $customFields, $formSchemaUid);
-        $tableSchemaRecord = TableSchema::create([
-            'uid' => Str::ulid(),
-            'slug' => $slug . '-table',
-            'name' => $entity->entity_name . ' Table',
-            'description' => 'Auto-generated table for ' . $entity->entity_name,
-            'schema' => $tableSchema,
-            'extra_info' => [],
-            'status' => 'active',
-            'created_by' => auth()->id(),
-            'updated_by' => auth()->id(),
-        ]);
-
-        return $tableSchemaRecord->uid;
-    }
-
-    /**
-     * Generate form schema from custom fields
-     */
-    private function generateFormSchema($entity, $customFields, $metaFields = [])
-    {
-        $fields = array_merge(
-            $this->buildFormSchemaFields($customFields, false),
-            $this->buildFormSchemaFields($this->filterDisplayableMetaFields($metaFields), true)
-        );
-
-        return [
-            'info' => [
-                'icon' => 'far fa-lightbulb',
-                'innerHTML' => 'You are creating a new ' . $entity->entity_name
-            ],
-            'entity' => $this->generateTableName($entity->entity_name),
-            'method' => 'POST',
-            'endpoint' => url('/api/entity/store/' . $this->generateTableName($entity->entity_name)),
-            'floatinglabel' => false,
-            'enctype' => 'multipart/form-data',
-            'header' => [
-                'icon' => 'fas fa-database',
-                'text' => 'Create ' . $entity->entity_name
-            ],
-            'fields' => $fields,
-            'actions' => [
-                [
-                    'icon' => 'far fa-save',
-                    'type' => 'submit',
-                    'route' => '#',
-                    'element' => [
-                        'type' => 'button',
-                        'color' => 'success'
-                    ]
-                ]
-            ]
-        ];
-    }
-
-    private function buildFormSchemaFields(array $fields, bool $isMetaField): array
-    {
-        $schemaFields = [];
-        $inputTypeMapping = [
-            'text' => 'text',
-            'textarea' => 'textarea',
-            'number' => 'number',
-            'email' => 'email',
-            'datetime-local' => 'datetime-local',
-            'date' => 'date',
-            'time' => 'time',
-            'checkbox' => 'checkbox',
-            'select' => 'select',
-        ];
-
-        foreach ($fields as $field) {
-            $fieldId = $isMetaField ? ($field['meta_key'] ?? null) : ($field['name'] ?? null);
-            $fieldLabel = $field['label'] ?? Str::headline((string) $fieldId);
-
-            if (! $fieldId) {
-                continue;
-            }
-
-            $formField = [
-                'id' => $fieldId,
-                'type' => $inputTypeMapping[$field['input_type']] ?? 'text',
-                'label' => $fieldLabel,
-                'placeholder' => 'Enter ' . strtolower($fieldLabel),
-                'helpertext' => $fieldLabel . ' field',
-                'required' => ! empty($field['required']),
-                'size' => [
-                    'md' => 12
-                ]
-            ];
-
-            if (! empty($field['maxlength'])) {
-                $formField['maxLength'] = $field['maxlength'];
-            }
-
-            if (! empty($field['required'])) {
-                $formField['messages'] = [
-                    'required' => $fieldLabel . ' is required'
-                ];
-            }
-
-            if ($isMetaField) {
-                $formField['meta'] = true;
-            }
-
-            $schemaFields[] = $formField;
-        }
-
-        return $schemaFields;
-    }
-
-    private function filterDisplayableMetaFields(array $metaFields): array
-    {
-        return array_values(array_filter($metaFields, function ($field) {
-            return ($field['display'] ?? true) === true || ($field['display'] ?? 1) === 1;
-        }));
-    }
-
     private function extractCustomFieldsFromEntityFields(array $fields): array
     {
         $systemFieldNames = array_keys($this->getSystemFields());
@@ -718,59 +530,6 @@ class EntityController extends Controller
         return array_filter($fields, function ($field) use ($systemFieldNames) {
             return ! in_array($field['name'] ?? null, $systemFieldNames, true);
         });
-    }
-
-    /**
-     * Generate table schema with system fields and first 2 custom fields
-     */
-    private function generateTableSchema($entity, $customFields, $formSchemaUid)
-    {
-        $columns = [];
-        
-        $columns[] = [
-            'data' => 'id',
-            'title' => 'ID',
-            'visible' => true
-        ];
-
-        $customFieldArray = array_values($customFields);
-        $fieldsToShow = array_slice($customFieldArray, 0, 2);
-        
-        foreach ($fieldsToShow as $field) {
-            $columns[] = [
-                'data' => $field['name'],
-                'title' => $field['label'],
-                'visible' => true,
-                'link' => true,
-                'form-schema-uid' => $formSchemaUid
-            ];
-        }
-
-        $columns[] = [
-            'data' => 'status',
-            'title' => 'Status',
-            'visible' => true
-        ];
-        
-        $tableMeta = $entity->metas()
-        ->where('meta_key', 'table_name')
-        ->first();
-
-        $baseTableName = $tableMeta?->meta_value ?? $this->generateTableName($entity->entity_name);
-        
-
-        return [
-            'entity' => $this->pluralizeTableName($baseTableName),
-            'dt-options' => [
-                'columns' => $columns,
-                'options' => [
-                    'pageLength' => 10,
-                    'order' => [[0, 'desc']],
-                    'responsive' => true
-                ]
-            ],
-            'default_view_mode' => 'inbox'
-        ];
     }
 
     public function show($entityUid)

--- a/src/Models/BusinessEntity.php
+++ b/src/Models/BusinessEntity.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Iquesters\Foundation\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class BusinessEntity extends Model
+{
+    use HasFactory;
+
+    protected $table = 'business_entities';
+
+    protected $fillable = [
+        'uid',
+        'ref_module',
+        'business_entity_name',
+        'slug',
+        'desc',
+        'field_mapping',
+        'status',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'uid' => 'string',
+        'field_mapping' => 'array',
+    ];
+
+    public function metas(): HasMany
+    {
+        return $this->hasMany(BusinessEntityMeta::class, 'ref_parent');
+    }
+}

--- a/src/Models/BusinessEntityMeta.php
+++ b/src/Models/BusinessEntityMeta.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Iquesters\Foundation\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BusinessEntityMeta extends Model
+{
+    use HasFactory;
+
+    protected $table = 'business_entity_metas';
+
+    protected $fillable = [
+        'ref_parent',
+        'meta_key',
+        'meta_value',
+        'status',
+        'created_by',
+        'updated_by',
+    ];
+
+    public function businessEntity(): BelongsTo
+    {
+        return $this->belongsTo(BusinessEntity::class, 'ref_parent');
+    }
+}


### PR DESCRIPTION
### Changes Implemented

* Added support for creating and editing Business Entities.
* Added Business Entity name, module, and description fields.
* Replaced inline entity/table selection and primary checkbox with a modal-driven workflow.
* Added a left-aligned **Add Entity** button for entity selection.
* Reused the existing `modal.js` implementation from the User Interface module.
* Added support for marking selected entities as primary within the modal.
* Prevented duplicate entity selection by disabling already selected entities.
* Added relationship configuration between selected entities.
* Added association entities support.
* Supported relationship types:

  * belongs_to
  * has_one
  * has_many
  * many_to_many
  * morph_one
  * morph_many
  * morph_to
  * morph_to_many
  * morphed_by_many
  * has_one_through
  * has_many_through
* Stored relationship metadata inside the `field_mapping` JSON structure.

### Files Modified

* resources/views/business_entity/create-edit.blade.php
* resources/views/business_entity/index.blade.php
* routes/web.php
* src/Http/Controllers/BusinessEntityController.php
* src/Http/Controllers/EntityController.php

Closes #29 